### PR TITLE
Theme support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.2.2",
+	"version": "0.2.4",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
 	"files": [

--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -2,6 +2,7 @@ import { FC } from "react";
 import classnames from "classnames";
 
 import classes from "./Message.module.css";
+import "./theme.css";
 import ChatBubble from "./common/ChatBubble";
 import Header from "./common/Header";
 import { match, MatchConfig } from "./matcher";

--- a/src/common/ChatBubble.module.css
+++ b/src/common/ChatBubble.module.css
@@ -1,18 +1,17 @@
 .bubble {
-	border-radius: var(--webchat-bubble-border-radius, 15px);
-	border: var(--webchat-bubble-border-width, 1px) var(--webchat-bubble-border-style, solid)
-		var(--webchat-bubble-border-color, #ccc);
+	border-radius: 15px;
+	border: 1px solid var(--black-80);
 	padding: 12px;
 	max-width: 295px;
 	width: max-content;
 }
 
 :global(.bot) .bubble {
-	background-color: var(--webchat-bubble-background-bot, transparent);
+	background: var(--background-bot-message);
 }
 
 :global(.user) .bubble {
-	background-color: var(--webchat-bubble-background-user, #e7ebff);
-	border-color: var(--webchat-bubble-border-color-user, transparent);
+	background: var(--background-user-message);
+	border-color: transparent;
 	margin-inline-start: auto;
 }

--- a/src/demo.css
+++ b/src/demo.css
@@ -15,7 +15,6 @@
 		sans-serif;
 	margin-inline: auto;
 	width: 375px;
-	padding-inline: 20px;
 	height: 620px;
 	overflow-y: auto;
 	resize: both;

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,27 @@
+:root {
+    --primary-color: var(--webchat-primary-color, #2455E6);
+    --primary-color-hover: color-mix(in srgb, var(--primary-color), #000 20%);
+    --primary-color-disabled: color-mix(in srgb, var(--primary-color), #fff 90%);
+
+    --secondary-color: var(--webchat-secondary-color, #1a1a1a);
+    --secondary-color-hover: color-mix(in srgb, var(--secondary-color), #fff 20%);
+    --secondary-color-disabled: color-mix(in srgb, var(--secondary-color), #fff 90%);
+
+    --background-bot-message: var(--webchat-background-bot-message, #fff);
+    --background-user-message: var(--webchat-background-user-message, #e8ebff);
+
+    --text-link: var(--webchat-text-link, #6688ed);
+    --text-link-hover: color-mix(in srgb, var(--text-link), #000 20%);
+    --text-link-disabled: color-mix(in srgb, var(--text-link), #fff 90%);
+
+    --black-10: #1a1a1a;
+    --black-20: #333;
+    --black-40: #666;
+    --black-60: #999;
+    --black-80: #ccc;
+    --black-95: #f2f2f2;
+    --white: #fff;
+
+    --text-dark: var(--webchat-text-dark, --black-10);
+    --text-light: var(--webchat-text-light, --white);
+}


### PR DESCRIPTION
This PR adds a theme support to chat-components. We integrate colours given us from the design agency.

Webchat v3 branch already contains an example usage, where the primary colour propagates from the endpoint config to the components of this package.

