### PR TITLE
Types refinement and more bugfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,14 @@
 		"": {
 			"name": "@cognigy/chat-components",
 			"version": "0.3.1",
-			"devDependencies": {
+			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
+				"classnames": "^2.3.2",
+				"dompurify": "^3.0.6",
+				"react-player": "^2.13.0",
+				"swiper": "^11.0.4"
+			},
+			"devDependencies": {
 				"@cognigy/socket-client": "^5.0.0-beta.5",
 				"@testing-library/jest-dom": "^6.1.4",
 				"@testing-library/react": "^14.0.0",
@@ -19,8 +25,6 @@
 				"@typescript-eslint/parser": "^6.9.0",
 				"@vitejs/plugin-react-swc": "^3.4.0",
 				"@vitest/ui": "^0.34.6",
-				"classnames": "^2.3.2",
-				"dompurify": "^3.0.6",
 				"eslint": "^8.52.0",
 				"eslint-plugin-jsx-a11y": "^6.7.1",
 				"eslint-plugin-react-hooks": "^4.6.0",
@@ -28,8 +32,6 @@
 				"jsdom": "^22.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
-				"react-player": "^2.13.0",
-				"swiper": "^11.0.4",
 				"typescript": "^5.2.2",
 				"vite": "^4.5.0",
 				"vite-plugin-css-injected-by-js": "^3.3.0",
@@ -586,8 +588,7 @@
 		"node_modules/@braintree/sanitize-url": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
-			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
-			"dev": true
+			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
 		},
 		"node_modules/@cognigy/socket-client": {
 			"version": "5.0.0-beta.5",
@@ -2625,8 +2626,7 @@
 		"node_modules/classnames": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-			"dev": true
+			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
@@ -2828,7 +2828,6 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2942,8 +2941,7 @@
 		"node_modules/dompurify": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-			"integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w==",
-			"dev": true
+			"integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
 		},
 		"node_modules/dot-case": {
 			"version": "3.0.4",
@@ -4292,8 +4290,7 @@
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -4464,8 +4461,7 @@
 		"node_modules/load-script": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
-			"dev": true
+			"integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
 		},
 		"node_modules/local-pkg": {
 			"version": "0.4.3",
@@ -4510,7 +4506,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			},
@@ -4572,8 +4567,7 @@
 		"node_modules/memoize-one": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-			"integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-			"dev": true
+			"integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -4716,7 +4710,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5066,7 +5059,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -5076,8 +5068,7 @@
 		"node_modules/prop-types/node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"node_modules/psl": {
 			"version": "1.9.0",
@@ -5139,7 +5130,6 @@
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
 			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -5163,8 +5153,7 @@
 		"node_modules/react-fast-compare": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-			"integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-			"dev": true
+			"integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
 		},
 		"node_modules/react-is": {
 			"version": "17.0.2",
@@ -5176,7 +5165,6 @@
 			"version": "2.13.0",
 			"resolved": "https://registry.npmjs.org/react-player/-/react-player-2.13.0.tgz",
 			"integrity": "sha512-gkY7ZdbVFztlKFFhCPcnDrFQm+L399b8fhWsKatZ+b2wpKJwfUHBXQFMRxqYQGT0ic1/wQ7D7EZEWy7ZBqk2pw==",
-			"dev": true,
 			"dependencies": {
 				"deepmerge": "^4.0.0",
 				"load-script": "^1.0.0",
@@ -5662,7 +5650,6 @@
 			"version": "11.0.4",
 			"resolved": "https://registry.npmjs.org/swiper/-/swiper-11.0.4.tgz",
 			"integrity": "sha512-qtUxILrD4aD++rpKzGrkz3IAWL92f9uTrDwjb6HaNLmPvJhZCE/83DL+9w4kIgDDJeF6QKalV47rMBN77UOVYQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "patreon",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,15 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.3.0",
-			"dependencies": {
-				"@braintree/sanitize-url": "^6.0.4",
-				"@cognigy/socket-client": "^5.0.0-beta.2",
-				"classnames": "^2.3.2",
-				"dompurify": "^3.0.6",
-				"react-player": "^2.13.0",
-				"swiper": "^11.0.4"
-			},
+			"version": "0.3.1",
 			"devDependencies": {
-				"@cognigy/socket-client": "^5.0.0-beta.2",
+				"@braintree/sanitize-url": "^6.0.4",
+				"@cognigy/socket-client": "^5.0.0-beta.5",
 				"@testing-library/jest-dom": "^6.1.4",
 				"@testing-library/react": "^14.0.0",
 				"@types/dompurify": "^3.0.5",
@@ -26,6 +19,8 @@
 				"@typescript-eslint/parser": "^6.9.0",
 				"@vitejs/plugin-react-swc": "^3.4.0",
 				"@vitest/ui": "^0.34.6",
+				"classnames": "^2.3.2",
+				"dompurify": "^3.0.6",
 				"eslint": "^8.52.0",
 				"eslint-plugin-jsx-a11y": "^6.7.1",
 				"eslint-plugin-react-hooks": "^4.6.0",
@@ -33,6 +28,8 @@
 				"jsdom": "^22.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
+				"react-player": "^2.13.0",
+				"swiper": "^11.0.4",
 				"typescript": "^5.2.2",
 				"vite": "^4.5.0",
 				"vite-plugin-css-injected-by-js": "^3.3.0",
@@ -589,12 +586,13 @@
 		"node_modules/@braintree/sanitize-url": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
-			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
+			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
+			"dev": true
 		},
 		"node_modules/@cognigy/socket-client": {
-			"version": "5.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-5.0.0-beta.2.tgz",
-			"integrity": "sha512-Id/3sx56qphKq0vgCKLzov+pICBrZrrUIkGSkpXWPtuhya8wqWMDGFyIV8rCEpxlfnOjAV6rh4l1eE+B1tF0Bw==",
+			"version": "5.0.0-beta.5",
+			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-5.0.0-beta.5.tgz",
+			"integrity": "sha512-ChJ7UQrNmD+pEQwJyGgsWG1hCYeYpIZVFA1758iHA6PsmDFcSEKXEoGG1EMn10V5yWxXXTTzKsuEJiDTf9b7aw==",
 			"dev": true,
 			"dependencies": {
 				"detect-browser": "^4.8.0",
@@ -2627,7 +2625,8 @@
 		"node_modules/classnames": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
+			"dev": true
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
@@ -2829,6 +2828,7 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2942,7 +2942,8 @@
 		"node_modules/dompurify": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-			"integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+			"integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w==",
+			"dev": true
 		},
 		"node_modules/dot-case": {
 			"version": "3.0.4",
@@ -4291,7 +4292,8 @@
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -4462,7 +4464,8 @@
 		"node_modules/load-script": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
+			"integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
+			"dev": true
 		},
 		"node_modules/local-pkg": {
 			"version": "0.4.3",
@@ -4507,6 +4510,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			},
@@ -4568,7 +4572,8 @@
 		"node_modules/memoize-one": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-			"integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+			"integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+			"dev": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -4711,6 +4716,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5060,6 +5066,7 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -5069,7 +5076,8 @@
 		"node_modules/prop-types/node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true
 		},
 		"node_modules/psl": {
 			"version": "1.9.0",
@@ -5131,6 +5139,7 @@
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
 			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -5154,7 +5163,8 @@
 		"node_modules/react-fast-compare": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-			"integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+			"integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+			"dev": true
 		},
 		"node_modules/react-is": {
 			"version": "17.0.2",
@@ -5166,6 +5176,7 @@
 			"version": "2.13.0",
 			"resolved": "https://registry.npmjs.org/react-player/-/react-player-2.13.0.tgz",
 			"integrity": "sha512-gkY7ZdbVFztlKFFhCPcnDrFQm+L399b8fhWsKatZ+b2wpKJwfUHBXQFMRxqYQGT0ic1/wQ7D7EZEWy7ZBqk2pw==",
+			"dev": true,
 			"dependencies": {
 				"deepmerge": "^4.0.0",
 				"load-script": "^1.0.0",
@@ -5651,6 +5662,7 @@
 			"version": "11.0.4",
 			"resolved": "https://registry.npmjs.org/swiper/-/swiper-11.0.4.tgz",
 			"integrity": "sha512-qtUxILrD4aD++rpKzGrkz3IAWL92f9uTrDwjb6HaNLmPvJhZCE/83DL+9w4kIgDDJeF6QKalV47rMBN77UOVYQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "patreon",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 		"test:watch": "vitest"
 	},
 	"devDependencies": {
-		"@braintree/sanitize-url": "^6.0.4",
 		"@cognigy/socket-client": "^5.0.0-beta.5",
 		"@testing-library/jest-dom": "^6.1.4",
 		"@testing-library/react": "^14.0.0",
@@ -29,8 +28,6 @@
 		"@typescript-eslint/parser": "^6.9.0",
 		"@vitejs/plugin-react-swc": "^3.4.0",
 		"@vitest/ui": "^0.34.6",
-		"classnames": "^2.3.2",
-		"dompurify": "^3.0.6",
 		"eslint": "^8.52.0",
 		"eslint-plugin-jsx-a11y": "^6.7.1",
 		"eslint-plugin-react-hooks": "^4.6.0",
@@ -38,14 +35,19 @@
 		"jsdom": "^22.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"react-player": "^2.13.0",
-		"swiper": "^11.0.4",
 		"typescript": "^5.2.2",
 		"vite": "^4.5.0",
 		"vite-plugin-css-injected-by-js": "^3.3.0",
 		"vite-plugin-svgr": "^4.1.0",
 		"vitest": "^0.34.6",
 		"vitest-github-actions-reporter": "^0.10.0"
+	},
+	"dependencies": {
+		"@braintree/sanitize-url": "^6.0.4",
+		"classnames": "^2.3.2",
+		"dompurify": "^3.0.6",
+		"react-player": "^2.13.0",
+		"swiper": "^11.0.4"
 	},
 	"peerDependencies": {
 		"react": "^17.x || 18.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
 	"files": [
@@ -18,7 +18,8 @@
 		"test:watch": "vitest"
 	},
 	"devDependencies": {
-		"@cognigy/socket-client": "^5.0.0-beta.2",
+		"@braintree/sanitize-url": "^6.0.4",
+		"@cognigy/socket-client": "^5.0.0-beta.5",
 		"@testing-library/jest-dom": "^6.1.4",
 		"@testing-library/react": "^14.0.0",
 		"@types/dompurify": "^3.0.5",
@@ -28,6 +29,8 @@
 		"@typescript-eslint/parser": "^6.9.0",
 		"@vitejs/plugin-react-swc": "^3.4.0",
 		"@vitest/ui": "^0.34.6",
+		"classnames": "^2.3.2",
+		"dompurify": "^3.0.6",
 		"eslint": "^8.52.0",
 		"eslint-plugin-jsx-a11y": "^6.7.1",
 		"eslint-plugin-react-hooks": "^4.6.0",
@@ -35,20 +38,14 @@
 		"jsdom": "^22.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
+		"react-player": "^2.13.0",
+		"swiper": "^11.0.4",
 		"typescript": "^5.2.2",
 		"vite": "^4.5.0",
 		"vite-plugin-css-injected-by-js": "^3.3.0",
 		"vite-plugin-svgr": "^4.1.0",
 		"vitest": "^0.34.6",
 		"vitest-github-actions-reporter": "^0.10.0"
-	},
-	"dependencies": {
-		"@braintree/sanitize-url": "^6.0.4",
-		"@cognigy/socket-client": "^5.0.0-beta.2",
-		"classnames": "^2.3.2",
-		"dompurify": "^3.0.6",
-		"react-player": "^2.13.0",
-		"swiper": "^11.0.4"
 	},
 	"peerDependencies": {
 		"react": "^17.x || 18.x",

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -1,7 +1,4 @@
-import {
-	IWebchatButton,
-	IWebchatQuickReply,
-} from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatButton, IWebchatQuickReply } from "@cognigy/socket-client";
 import { ActionButton } from ".";
 import classnames from "classnames";
 

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -20,6 +20,9 @@ export interface ActionButtonsProps {
 
 const ActionButtons: FC<ActionButtonsProps> = props => {
 	const { payload, buttonClassName, containerClassName, action, customIcon, showUrlIcon } = props;
+
+	if (payload?.length === 0) return null;
+
 	const buttons = payload.filter((button: ActionButtonsProps["payload"][number]) => {
 		if ("type" in button && !["postback", "web_url", "phone_number"].includes(button.type))
 			return false;

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -18,7 +18,7 @@ export interface ActionButtonsProps {
 const ActionButtons: FC<ActionButtonsProps> = props => {
 	const { payload, buttonClassName, containerClassName, action, customIcon, showUrlIcon } = props;
 
-	if (payload?.length === 0) return null;
+	if (!payload || payload?.length === 0) return null;
 
 	const buttons = payload.filter((button: ActionButtonsProps["payload"][number]) => {
 		if ("type" in button && !["postback", "web_url", "phone_number"].includes(button.type))

--- a/src/common/ActionButtons/PrimaryButton.tsx
+++ b/src/common/ActionButtons/PrimaryButton.tsx
@@ -6,7 +6,7 @@ import { IWebchatButton } from "@cognigy/socket-client";
 
 interface PrimaryButtonProps extends HTMLAttributes<HTMLDivElement> {
 	action?: ActionButtonsProps["action"];
-	button: IWebchatButton;
+	button?: IWebchatButton | null;
 	buttonClassName?: string;
 	containerClassName?: string;
 	customIcon?: ReactElement;

--- a/src/common/ActionButtons/PrimaryButton.tsx
+++ b/src/common/ActionButtons/PrimaryButton.tsx
@@ -2,7 +2,7 @@ import { FC, HTMLAttributes, ReactElement } from "react";
 import classes from "./SingleButtons.module.css";
 import classnames from "classnames";
 import ActionButtons, { ActionButtonsProps } from "./ActionButtons";
-import { IWebchatButton } from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatButton } from "@cognigy/socket-client";
 
 interface PrimaryButtonProps extends HTMLAttributes<HTMLDivElement> {
 	action?: ActionButtonsProps["action"];

--- a/src/common/ActionButtons/SecondaryButton.tsx
+++ b/src/common/ActionButtons/SecondaryButton.tsx
@@ -6,7 +6,7 @@ import { IWebchatButton } from "@cognigy/socket-client";
 
 interface SecondaryButtonProps extends HTMLAttributes<HTMLDivElement> {
 	action?: ActionButtonsProps["action"];
-	button: IWebchatButton;
+	button?: IWebchatButton | null;
 	buttonClassName?: string;
 	containerClassName?: string;
 	customIcon?: ReactElement;

--- a/src/common/ActionButtons/SecondaryButton.tsx
+++ b/src/common/ActionButtons/SecondaryButton.tsx
@@ -2,7 +2,7 @@ import { FC, HTMLAttributes, ReactElement } from "react";
 import classes from "./SingleButtons.module.css";
 import classnames from "classnames";
 import ActionButtons, { ActionButtonsProps } from "./ActionButtons";
-import { IWebchatButton } from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatButton } from "@cognigy/socket-client";
 
 interface SecondaryButtonProps extends HTMLAttributes<HTMLDivElement> {
 	action?: ActionButtonsProps["action"];

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 
 import "./demo.css";
 import Message, { MessageProps } from "./messages/Message.tsx";
-import { MessageSender } from "./messages/types.ts";
+import { MessageSender, WebchatMessage } from "./messages/types.ts";
 
 //fixtures
 import listMessage from "test/fixtures/list.json";
@@ -18,7 +18,7 @@ import audio from "test/fixtures/audio.json";
 const messages: MessageProps[] = [
 	{
 		message: {
-			avatarNane: "Dognigy",
+			avatarName: "Cognigy",
 			text: "",
 			data: {
 				_cognigy: {
@@ -118,7 +118,7 @@ const messages: MessageProps[] = [
 		disableHeader: true,
 	},
 	{
-		message: image,
+		message: image as WebchatMessage,
 	},
 	{
 		message: {
@@ -134,25 +134,25 @@ const messages: MessageProps[] = [
 		},
 	},
 	{
-		message: imageBroken,
+		message: imageBroken as WebchatMessage,
 	},
 	{
-		message: imageDownloadable,
+		message: imageDownloadable as WebchatMessage,
 	},
 	{
-		message: video,
+		message: video as WebchatMessage,
 	},
 	{
-		message: videoYoutube,
+		message: videoYoutube as WebchatMessage,
 	},
 	{
-		message: audio,
+		message: audio as WebchatMessage,
 	},
 	{
-		message: listMessage,
+		message: listMessage as WebchatMessage,
 	},
 	{
-		message: gallery,
+		message: gallery as WebchatMessage,
 	},
 ];
 

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 
 import "./demo.css";
 import Message, { MessageProps } from "./messages/Message.tsx";
-import { MessageSender, WebchatMessage } from "./messages/types.ts";
+import { MessageSender } from "./messages/types.ts";
 
 //fixtures
 import listMessage from "test/fixtures/list.json";
@@ -14,6 +14,7 @@ import imageBroken from "test/fixtures/imageBroken.json";
 import video from "test/fixtures/video.json";
 import videoYoutube from "test/fixtures/videoYoutube.json";
 import audio from "test/fixtures/audio.json";
+import { IMessage } from "@cognigy/socket-client";
 
 const messages: MessageProps[] = [
 	{
@@ -118,7 +119,7 @@ const messages: MessageProps[] = [
 		disableHeader: true,
 	},
 	{
-		message: image as WebchatMessage,
+		message: image as IMessage,
 	},
 	{
 		message: {
@@ -134,25 +135,25 @@ const messages: MessageProps[] = [
 		},
 	},
 	{
-		message: imageBroken as WebchatMessage,
+		message: imageBroken as IMessage,
 	},
 	{
-		message: imageDownloadable as WebchatMessage,
+		message: imageDownloadable as IMessage,
 	},
 	{
-		message: video as WebchatMessage,
+		message: video as IMessage,
 	},
 	{
-		message: videoYoutube as WebchatMessage,
+		message: videoYoutube as IMessage,
 	},
 	{
-		message: audio as WebchatMessage,
+		message: audio as IMessage,
 	},
 	{
-		message: listMessage as WebchatMessage,
+		message: listMessage as IMessage,
 	},
 	{
-		message: gallery as WebchatMessage,
+		message: gallery as IMessage,
 	},
 ];
 

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -74,7 +74,10 @@ const defaultConfig: MatchConfig[] = [
 			const channelConfig = getChannelPayload(message, config);
 			if (!channelConfig) return false;
 
-			return channelConfig?.message?.attachment?.payload?.template_type === "list";
+			return (
+				(channelConfig.message?.attachment as IWebchatTemplateAttachment).payload
+					.template_type === "list"
+			);
 		},
 		component: List,
 	},
@@ -83,7 +86,10 @@ const defaultConfig: MatchConfig[] = [
 			const channelConfig = getChannelPayload(message, config);
 			if (!channelConfig) return false;
 
-			return channelConfig?.message?.attachment?.payload?.template_type === "generic";
+			return (
+				(channelConfig.message?.attachment as IWebchatTemplateAttachment).payload
+					.template_type === "generic"
+			);
 		},
 		component: Gallery,
 	},

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,11 +1,11 @@
 import { FunctionComponent } from "react";
 import { Text, Image, Video, Audio, List, Gallery, TextWithButtons } from "./messages";
-import { IWebchatConfig, WebchatMessage } from "./messages/types";
+import { IWebchatConfig } from "./messages/types";
 import { getChannelPayload } from "./utils";
-import { IWebchatTemplateAttachment } from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IMessage, IWebchatTemplateAttachment } from "@cognigy/socket-client";
 
 export type MatchConfig = {
-	rule: (message: WebchatMessage, config?: IWebchatConfig) => boolean;
+	rule: (message: IMessage, config?: IWebchatConfig) => boolean;
 	component: FunctionComponent;
 };
 
@@ -100,7 +100,7 @@ const defaultConfig: MatchConfig[] = [
  * Accepts `configExtended` to extend with custom rules.
  */
 export function match(
-	message: WebchatMessage,
+	message: IMessage,
 	webchatConfig?: IWebchatConfig,
 	configExtended: MatchConfig[] = [],
 ) {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -75,8 +75,8 @@ const defaultConfig: MatchConfig[] = [
 			if (!channelConfig) return false;
 
 			return (
-				(channelConfig.message?.attachment as IWebchatTemplateAttachment).payload
-					.template_type === "list"
+				(channelConfig.message?.attachment as IWebchatTemplateAttachment)?.payload
+					?.template_type === "list"
 			);
 		},
 		component: List,
@@ -87,8 +87,8 @@ const defaultConfig: MatchConfig[] = [
 			if (!channelConfig) return false;
 
 			return (
-				(channelConfig.message?.attachment as IWebchatTemplateAttachment).payload
-					.template_type === "generic"
+				(channelConfig.message?.attachment as IWebchatTemplateAttachment)?.payload
+					?.template_type === "generic"
 			);
 		},
 		component: Gallery,

--- a/src/messages/Audio/Audio.tsx
+++ b/src/messages/Audio/Audio.tsx
@@ -7,16 +7,17 @@ import Controls from "./Controls";
 import { OnProgressProps } from "react-player/base";
 import { useMessageContext } from "src/messages/hooks";
 import { getChannelPayload } from "src/utils";
+import { IWebchatAudioAttachment } from "@cognigy/socket-client/lib/interfaces/messageData";
 
 const Audio: FC = () => {
 	const { message, config } = useMessageContext();
 	const payload = getChannelPayload(message, config);
-	const { url, altText } = payload.message.attachment?.payload || {};
+	const { url, altText } = (payload?.message?.attachment as IWebchatAudioAttachment).payload;
 
 	const playerRef = useRef<ReactPlayer | null>(null);
-	const [playing, setPlaying] = useState<boolean>(false);
-	const [progress, setProgress] = useState<number>(0);
-	const [duration, setDuration] = useState<number>(0);
+	const [playing, setPlaying] = useState(false);
+	const [progress, setProgress] = useState(0);
+	const [duration, setDuration] = useState(0);
 
 	const handleFocus = useCallback(
 		(player: ReactPlayer) => {

--- a/src/messages/Audio/Audio.tsx
+++ b/src/messages/Audio/Audio.tsx
@@ -7,7 +7,7 @@ import Controls from "./Controls";
 import { OnProgressProps } from "react-player/base";
 import { useMessageContext } from "src/messages/hooks";
 import { getChannelPayload } from "src/utils";
-import { IWebchatAudioAttachment } from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatAudioAttachment } from "@cognigy/socket-client";
 
 const Audio: FC = () => {
 	const { message, config } = useMessageContext();

--- a/src/messages/Audio/Audio.tsx
+++ b/src/messages/Audio/Audio.tsx
@@ -12,7 +12,8 @@ import { IWebchatAudioAttachment } from "@cognigy/socket-client";
 const Audio: FC = () => {
 	const { message, config } = useMessageContext();
 	const payload = getChannelPayload(message, config);
-	const { url, altText } = (payload?.message?.attachment as IWebchatAudioAttachment).payload;
+	const { url, altText } =
+		(payload?.message?.attachment as IWebchatAudioAttachment)?.payload || {};
 
 	const playerRef = useRef<ReactPlayer | null>(null);
 	const [playing, setPlaying] = useState(false);

--- a/src/messages/Audio/Controls.tsx
+++ b/src/messages/Audio/Controls.tsx
@@ -40,7 +40,7 @@ const Controls: FC<ControlsProps> = props => {
 			return ("0" + string).slice(-2);
 		};
 
-		const seconds = duration * (1 - progress);
+		const seconds = duration * (1 - Math.min(1, progress));
 		const date = new Date(seconds * 1000);
 		const hh = date.getUTCHours();
 		const mm = date.getUTCMinutes();

--- a/src/messages/Gallery/Gallery.tsx
+++ b/src/messages/Gallery/Gallery.tsx
@@ -12,7 +12,8 @@ import { IWebchatAttachmentElement, IWebchatTemplateAttachment } from "@cognigy/
 const Gallery: FC = () => {
 	const { message, config } = useMessageContext();
 	const payload = getChannelPayload(message, config);
-	const { elements } = (payload?.message?.attachment as IWebchatTemplateAttachment).payload;
+	const { elements } =
+		(payload?.message?.attachment as IWebchatTemplateAttachment)?.payload || {};
 
 	const carouselContentId = useMemo(() => getRandomId("webchatCarouselContentButton"), []);
 

--- a/src/messages/Gallery/Gallery.tsx
+++ b/src/messages/Gallery/Gallery.tsx
@@ -7,10 +7,7 @@ import { ArrowBack as ArrowNavIcon } from "src/assets/svg";
 import { Navigation, Pagination, A11y } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import GalleryItem from "./GalleryItem";
-import {
-	IWebchatAttachmentElement,
-	IWebchatTemplateAttachment,
-} from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatAttachmentElement, IWebchatTemplateAttachment } from "@cognigy/socket-client";
 
 const Gallery: FC = () => {
 	const { message, config } = useMessageContext();

--- a/src/messages/Gallery/Gallery.tsx
+++ b/src/messages/Gallery/Gallery.tsx
@@ -7,12 +7,15 @@ import { ArrowBack as ArrowNavIcon } from "src/assets/svg";
 import { Navigation, Pagination, A11y } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import GalleryItem from "./GalleryItem";
-import { IWebchatAttachmentElement } from "@cognigy/socket-client/lib/interfaces/messageData";
+import {
+	IWebchatAttachmentElement,
+	IWebchatTemplateAttachment,
+} from "@cognigy/socket-client/lib/interfaces/messageData";
 
 const Gallery: FC = () => {
 	const { message, config } = useMessageContext();
 	const payload = getChannelPayload(message, config);
-	const { elements } = payload.message.attachment?.payload || {};
+	const { elements } = (payload?.message?.attachment as IWebchatTemplateAttachment).payload;
 
 	const carouselContentId = useMemo(() => getRandomId("webchatCarouselContentButton"), []);
 

--- a/src/messages/Gallery/Gallery.tsx
+++ b/src/messages/Gallery/Gallery.tsx
@@ -38,7 +38,7 @@ const Gallery: FC = () => {
 		}
 	}, [carouselContentId, config?.settings.enableAutoFocus]);
 
-	if (!elements || elements.length === 0) return null;
+	if (!elements || elements?.length === 0) return null;
 
 	if (elements.length === 1)
 		return (

--- a/src/messages/Gallery/Gallery.tsx
+++ b/src/messages/Gallery/Gallery.tsx
@@ -37,7 +37,7 @@ const Gallery: FC = () => {
 		}
 	}, [carouselContentId, config?.settings.enableAutoFocus]);
 
-	if (elements.length === 0) return null;
+	if (!elements || elements.length === 0) return null;
 
 	if (elements.length === 1)
 		return (

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -18,7 +18,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 	const { slide, contentId } = props;
 	const { title, subtitle, image_url, image_alt_text, buttons, default_action } = slide;
 	const { action, config } = useMessageContext();
-	const hasExtraInfo = subtitle || buttons?.length > 0;
+	const hasExtraInfo = subtitle || buttons && buttons?.length > 0;
 	const [isImageBroken, setImageBroken] = useState(false);
 
 	const isSanitizeEnabled = !config?.settings?.disableHtmlContentSanitization;
@@ -84,7 +84,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 							className="webchat-carousel-template-subtitle"
 						/>
 					)}
-					{buttons?.length > 0 && (
+					{buttons && buttons?.length > 0 && (
 						<ActionButtons
 							buttonClassName={classnames(
 								buttonClasses.primaryButton,

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -18,7 +18,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 	const { slide, contentId } = props;
 	const { title, subtitle, image_url, image_alt_text, buttons, default_action } = slide;
 	const { action, config } = useMessageContext();
-	const hasExtraInfo = subtitle || buttons.length > 0;
+	const hasExtraInfo = subtitle || buttons?.length > 0;
 	const [isImageBroken, setImageBroken] = useState(false);
 
 	const isSanitizeEnabled = !config?.settings?.disableHtmlContentSanitization;

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -18,7 +18,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 	const { slide, contentId } = props;
 	const { title, subtitle, image_url, image_alt_text, buttons, default_action } = slide;
 	const { action, config } = useMessageContext();
-	const hasExtraInfo = subtitle || buttons && buttons?.length > 0;
+	const hasExtraInfo = subtitle || (buttons && buttons?.length > 0);
 	const [isImageBroken, setImageBroken] = useState(false);
 
 	const isSanitizeEnabled = !config?.settings?.disableHtmlContentSanitization;

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -1,4 +1,4 @@
-import { IWebchatAttachmentElement } from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatAttachmentElement } from "@cognigy/socket-client";
 import { FC, KeyboardEvent, useMemo, useState } from "react";
 import classes from "./Gallery.module.css";
 import buttonClasses from "src/common/ActionButtons/SingleButtons.module.css";

--- a/src/messages/Image/Image.tsx
+++ b/src/messages/Image/Image.tsx
@@ -9,8 +9,8 @@ import { IWebchatButton, IWebchatImageAttachment } from "@cognigy/socket-client"
 const Image: FC = () => {
 	const { message, config } = useMessageContext();
 	const payload = getChannelPayload(message, config);
-	const { url, altText, buttons } = (payload?.message?.attachment as IWebchatImageAttachment)
-		.payload;
+	const { url, altText, buttons } =
+		(payload?.message?.attachment as IWebchatImageAttachment)?.payload || {};
 
 	const button = buttons?.[0];
 

--- a/src/messages/Image/Image.tsx
+++ b/src/messages/Image/Image.tsx
@@ -4,14 +4,18 @@ import Lightbox from "./lightbox/Lightbox";
 import ImageThumb from "./ImageThumb";
 import { useMessageContext } from "src/messages/hooks";
 import { getChannelPayload } from "src/utils";
-import { IWebchatButton } from "@cognigy/socket-client/lib/interfaces/messageData";
+import {
+	IWebchatButton,
+	IWebchatImageAttachment,
+} from "@cognigy/socket-client/lib/interfaces/messageData";
 
 const Image: FC = () => {
 	const { message, config } = useMessageContext();
 	const payload = getChannelPayload(message, config);
-	const { url, altText, buttons } = payload.message.attachment?.payload || {};
+	const { url, altText, buttons } = (payload?.message?.attachment as IWebchatImageAttachment)
+		.payload;
 
-	const button: IWebchatButton = buttons?.[0];
+	const button = buttons?.[0];
 
 	const isDownloadable =
 		(buttons as IWebchatButton[])?.find(

--- a/src/messages/Image/Image.tsx
+++ b/src/messages/Image/Image.tsx
@@ -4,10 +4,7 @@ import Lightbox from "./lightbox/Lightbox";
 import ImageThumb from "./ImageThumb";
 import { useMessageContext } from "src/messages/hooks";
 import { getChannelPayload } from "src/utils";
-import {
-	IWebchatButton,
-	IWebchatImageAttachment,
-} from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatButton, IWebchatImageAttachment } from "@cognigy/socket-client";
 
 const Image: FC = () => {
 	const { message, config } = useMessageContext();

--- a/src/messages/Image/context.tsx
+++ b/src/messages/Image/context.tsx
@@ -1,4 +1,4 @@
-import { IWebchatButton } from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatButton } from "@cognigy/socket-client";
 import { createContext } from "react";
 
 export interface IImageContext {

--- a/src/messages/List/List.tsx
+++ b/src/messages/List/List.tsx
@@ -6,10 +6,7 @@ import classes from "./List.module.css";
 import classnames from "classnames";
 import { PrimaryButton } from "src/common/ActionButtons";
 import { getChannelPayload, getRandomId } from "src/utils";
-import {
-	IWebchatAttachmentElement,
-	IWebchatTemplateAttachment,
-} from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatAttachmentElement, IWebchatTemplateAttachment } from "@cognigy/socket-client";
 
 const List: FC = () => {
 	const { message, config, action } = useMessageContext();

--- a/src/messages/List/List.tsx
+++ b/src/messages/List/List.tsx
@@ -41,7 +41,7 @@ const List: FC = () => {
 		}, 200);
 	}, [config?.settings.enableAutoFocus, listTemplateId]);
 
-	if (!elements || elements.length === 0) return null;
+	if (!elements || elements?.length === 0) return null;
 
 	return (
 		<div
@@ -51,7 +51,7 @@ const List: FC = () => {
 			data-testid="list-message"
 		>
 			{headerElement && <ListItem element={headerElement} isHeaderElement />}
-			{regularElements?.map((element: IWebchatAttachmentElement, index: number) => (
+			{regularElements && regularElements.map((element: IWebchatAttachmentElement, index: number) => (
 				<Fragment key={index}>
 					{index > 0 && <div className={mainclasses.divider} />}
 					<ListItem element={element} />

--- a/src/messages/List/List.tsx
+++ b/src/messages/List/List.tsx
@@ -6,13 +6,18 @@ import classes from "./List.module.css";
 import classnames from "classnames";
 import { PrimaryButton } from "src/common/ActionButtons";
 import { getChannelPayload, getRandomId } from "src/utils";
-import { IWebchatAttachmentElement } from "@cognigy/socket-client/lib/interfaces/messageData";
+import {
+	IWebchatAttachmentElement,
+	IWebchatTemplateAttachment,
+} from "@cognigy/socket-client/lib/interfaces/messageData";
 
 const List: FC = () => {
 	const { message, config, action } = useMessageContext();
 	const payload = getChannelPayload(message, config);
 
-	const { elements, top_element_style, buttons } = payload.message.attachment?.payload || {};
+	const { elements, top_element_style, buttons } = (
+		payload?.message?.attachment as IWebchatTemplateAttachment
+	).payload;
 
 	// We support the "large" string to maintain compatibility with old format
 	const showTopElementLarge = top_element_style === "large" || top_element_style === true;
@@ -50,7 +55,7 @@ const List: FC = () => {
 			data-testid="list-message"
 		>
 			{headerElement && <ListItem element={headerElement} isHeaderElement />}
-			{regularElements.map((element: IWebchatAttachmentElement, index: number) => (
+			{regularElements?.map((element: IWebchatAttachmentElement, index: number) => (
 				<Fragment key={index}>
 					{index > 0 && <div className={mainclasses.divider} />}
 					<ListItem element={element} />

--- a/src/messages/List/List.tsx
+++ b/src/messages/List/List.tsx
@@ -17,9 +17,9 @@ const List: FC = () => {
 	// We support the "large" string to maintain compatibility with old format
 	const showTopElementLarge = top_element_style === "large" || top_element_style === true;
 
-	const regularElements = showTopElementLarge ? elements.slice(1) : elements;
-	const headerElement = showTopElementLarge ? elements[0] : null;
-	const button = buttons && buttons[0];
+	const regularElements = showTopElementLarge ? elements?.slice(1) : elements;
+	const headerElement = showTopElementLarge ? elements?.[0] : null;
+	const button = buttons && buttons?.[0];
 	const listTemplateId = useMemo(() => getRandomId("webchatListTemplateRoot"), []);
 
 	useEffect(() => {
@@ -40,7 +40,7 @@ const List: FC = () => {
 		}, 200);
 	}, [config?.settings.enableAutoFocus, listTemplateId]);
 
-	if (elements.length === 0) return null;
+	if (!elements || elements.length === 0) return null;
 
 	return (
 		<div

--- a/src/messages/List/List.tsx
+++ b/src/messages/List/List.tsx
@@ -12,9 +12,8 @@ const List: FC = () => {
 	const { message, config, action } = useMessageContext();
 	const payload = getChannelPayload(message, config);
 
-	const { elements, top_element_style, buttons } = (
-		payload?.message?.attachment as IWebchatTemplateAttachment
-	).payload;
+	const { elements, top_element_style, buttons } =
+		(payload?.message?.attachment as IWebchatTemplateAttachment)?.payload || {};
 
 	// We support the "large" string to maintain compatibility with old format
 	const showTopElementLarge = top_element_style === "large" || top_element_style === true;

--- a/src/messages/List/ListItem.tsx
+++ b/src/messages/List/ListItem.tsx
@@ -7,7 +7,7 @@ import { getBackgroundImage } from "src/utils";
 import { PrimaryButton, SecondaryButton } from "src/common/ActionButtons";
 import classnames from "classnames";
 import { sanitizeUrl } from "@braintree/sanitize-url";
-import { IWebchatAttachmentElement } from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatAttachmentElement } from "@cognigy/socket-client";
 
 const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boolean }> = props => {
 	const { action, config } = useMessageContext();

--- a/src/messages/List/ListItem.tsx
+++ b/src/messages/List/ListItem.tsx
@@ -13,7 +13,7 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 	const { action, config } = useMessageContext();
 	const { element, isHeaderElement } = props;
 	const { title, subtitle, image_url, image_alt_text, default_action, buttons } = element;
-	const button = buttons && buttons[0];
+	const button = buttons && buttons?.[0];
 
 	const handleClick = () => {
 		if (!default_action?.url) return;

--- a/src/messages/Message.tsx
+++ b/src/messages/Message.tsx
@@ -4,17 +4,18 @@ import classnames from "classnames";
 import MessageHeader from "../common/MessageHeader";
 import { match, MatchConfig } from "../matcher";
 import { MessageProvider } from "./context";
-import { IWebchatConfig, MessageSender, WebchatMessage } from "./types";
+import { IWebchatConfig, MessageSender } from "./types";
 
 import "src/theme.css";
 import classes from "./Message.module.css";
+import { IMessage } from "@cognigy/socket-client";
 
 export interface MessageProps {
 	action?: MessageSender;
 	className?: string;
 	config?: IWebchatConfig;
 	disableHeader?: boolean;
-	message: WebchatMessage;
+	message: IMessage;
 	plugins?: MatchConfig[];
 	onEmitAnalytics?: (event: string, payload?: unknown) => void;
 }

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -7,6 +7,7 @@ import { useMessageContext } from "../hooks";
 
 import { getChannelPayload } from "src/utils";
 import ActionButtons from "src/common/ActionButtons/ActionButtons";
+import { IWebchatTemplateAttachment } from "@cognigy/socket-client/lib/interfaces/messageData";
 
 /**
  * Combines Text with Buttons + Quick Replies media types as
@@ -17,9 +18,9 @@ const TextWithButtons: FC = () => {
 
 	const payload = getChannelPayload(message, config);
 
-	const text = payload?.message?.attachment?.payload?.text || payload?.message?.text || "";
-	const buttons =
-		payload?.message?.attachment?.payload?.buttons || payload?.message?.quick_replies || [];
+	const attachments = payload?.message?.attachment as IWebchatTemplateAttachment;
+	const text = attachments?.payload?.text || payload?.message?.text || "";
+	const buttons = attachments?.payload?.buttons || payload?.message?.quick_replies || [];
 
 	return (
 		<>

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -19,7 +19,7 @@ const TextWithButtons: FC = () => {
 
 	const text = payload?.message?.attachment?.payload?.text || payload?.message?.text || "";
 	const buttons =
-		payload?.message?.attachment?.payload?.buttons || payload?.message?.quick_replies || "";
+		payload?.message?.attachment?.payload?.buttons || payload?.message?.quick_replies || [];
 
 	return (
 		<>

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -7,7 +7,7 @@ import { useMessageContext } from "../hooks";
 
 import { getChannelPayload } from "src/utils";
 import ActionButtons from "src/common/ActionButtons/ActionButtons";
-import { IWebchatTemplateAttachment } from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatTemplateAttachment } from "@cognigy/socket-client";
 
 /**
  * Combines Text with Buttons + Quick Replies media types as

--- a/src/messages/Video/Video.tsx
+++ b/src/messages/Video/Video.tsx
@@ -11,7 +11,8 @@ import { IWebchatVideoAttachment } from "@cognigy/socket-client";
 const Video: FC = () => {
 	const { message, config } = useMessageContext();
 	const payload = getChannelPayload(message, config);
-	const { url, altText } = (payload?.message?.attachment as IWebchatVideoAttachment).payload;
+	const { url, altText } =
+		(payload?.message?.attachment as IWebchatVideoAttachment)?.payload || {};
 
 	const handleFocus = useCallback(
 		(player: ReactPlayer) => {

--- a/src/messages/Video/Video.tsx
+++ b/src/messages/Video/Video.tsx
@@ -6,11 +6,12 @@ import classnames from "classnames";
 import { VideoPlayIcon } from "src/assets/svg";
 import { useMessageContext } from "src/messages/hooks";
 import { getChannelPayload } from "src/utils";
+import { IWebchatVideoAttachment } from "@cognigy/socket-client/lib/interfaces/messageData";
 
 const Video: FC = () => {
 	const { message, config } = useMessageContext();
 	const payload = getChannelPayload(message, config);
-	const { url, altText } = payload.message.attachment?.payload || {};
+	const { url, altText } = (payload?.message?.attachment as IWebchatVideoAttachment).payload;
 
 	const handleFocus = useCallback(
 		(player: ReactPlayer) => {

--- a/src/messages/Video/Video.tsx
+++ b/src/messages/Video/Video.tsx
@@ -6,7 +6,7 @@ import classnames from "classnames";
 import { VideoPlayIcon } from "src/assets/svg";
 import { useMessageContext } from "src/messages/hooks";
 import { getChannelPayload } from "src/utils";
-import { IWebchatVideoAttachment } from "@cognigy/socket-client/lib/interfaces/messageData";
+import { IWebchatVideoAttachment } from "@cognigy/socket-client";
 
 const Video: FC = () => {
 	const { message, config } = useMessageContext();

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -1,20 +1,7 @@
 // import type { IOutput } from "@cognigy/socket-client";
 
-import { IMessageData } from "@cognigy/socket-client/lib/interfaces/messageData";
 import { MessageProps } from "src/messages/Message";
 
-// TODO publish WebchatMessage in Webchat npm package
-
-export type WebchatMessage = {
-	text?: string | null;
-	data?: IMessageData;
-	source?: "user" | "bot" | "engagement" | "agent" | string;
-	timestamp?: string;
-	avatarUrl?: string;
-	avatarName?: string;
-	disableSensitiveLogging?: boolean;
-	traceId?: string;
-};
 export type MessagePasstroughProps = Pick<MessageProps, "message" | "action">;
 
 export interface IPersistentMenuItem {
@@ -154,6 +141,7 @@ export interface ISendMessageOptions {
 	collate: boolean;
 }
 
+// TODO: move this one SocketClient repo or reuse an existing interface (IProcessOutputData?)
 export type MessageSender = (
 	text?: string,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -1,23 +1,21 @@
 // import type { IOutput } from "@cognigy/socket-client";
 
+import { IMessageData } from "@cognigy/socket-client/lib/interfaces/messageData";
 import { MessageProps } from "src/messages/Message";
 
 // TODO publish WebchatMessage in Webchat npm package
 
-export type WebchatMessage = any & {
+export type WebchatMessage = {
+	text?: string | null;
+	data?: IMessageData;
 	source?: "user" | "bot" | "engagement" | "agent" | string;
 	timestamp?: string;
 	avatarUrl?: string;
+	avatarName?: string;
+	disableSensitiveLogging?: boolean;
+	traceId?: string;
 };
 export type MessagePasstroughProps = Pick<MessageProps, "message" | "action">;
-
-export interface IMessageImage {
-	config: IWebchatConfig;
-	url: string;
-	isDownloadable?: boolean;
-	altText?: string;
-	template?: "media" | "list" | "generic";
-}
 
 export interface IPersistentMenuItem {
 	title: string;
@@ -158,6 +156,7 @@ export interface ISendMessageOptions {
 
 export type MessageSender = (
 	text?: string,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	data?: Record<string, any> | null,
 	options?: Partial<ISendMessageOptions>,
 ) => void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,11 @@
-import { IWebchatMessage } from "@cognigy/socket-client/lib/interfaces/messageData";
-import { IWebchatConfig, WebchatMessage } from "./messages/types";
+import { IMessage, IWebchatMessage } from "@cognigy/socket-client";
+import { IWebchatConfig } from "./messages/types";
 import { ActionButtonsProps } from "./common/ActionButtons/ActionButtons";
 
 /**
  * Decides between _webchat and _facebook payload.
  */
-export function getChannelPayload(message: WebchatMessage, config?: IWebchatConfig) {
+export function getChannelPayload(message: IMessage, config?: IWebchatConfig) {
 	const { _facebook, _webchat } = message?.data?._cognigy || {};
 
 	if (

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -2,10 +2,10 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import buttons from "test/fixtures/action-buttons.json";
-import { WebchatMessage } from "src/messages/types";
+import { IMessage } from "@cognigy/socket-client";
 
 describe("Action Buttons", () => {
-	const message = buttons as unknown as WebchatMessage;
+	const message = buttons as unknown as IMessage;
 
 	it("renders Action Buttons component", async () => {
 		await waitFor(() => {

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -2,11 +2,14 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import buttons from "test/fixtures/action-buttons.json";
+import { WebchatMessage } from "src/messages/types";
 
 describe("Action Buttons", () => {
+	const message = buttons as unknown as WebchatMessage;
+
 	it("renders Action Buttons component", async () => {
 		await waitFor(() => {
-			render(<Message message={buttons} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByTestId("action-buttons")).toBeInTheDocument();
@@ -14,7 +17,7 @@ describe("Action Buttons", () => {
 
 	it("renders buttons with proper role", async () => {
 		await waitFor(() => {
-			render(<Message message={buttons} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByRole("group")).toBeInTheDocument();
@@ -24,7 +27,7 @@ describe("Action Buttons", () => {
 
 	it("renders buttons in group with 'aria-label' attribute and position", async () => {
 		await waitFor(() => {
-			render(<Message message={buttons} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getAllByLabelText(/Item (1|2|3|4) of 4: foobar005b(1|2|3|4)/)).toHaveLength(
@@ -34,7 +37,7 @@ describe("Action Buttons", () => {
 
 	it("renders phone number button as anchor element with 'href' attribute", async () => {
 		await waitFor(() => {
-			render(<Message message={buttons} />);
+			render(<Message message={message} />);
 		});
 
 		const phoneButton = screen.getByLabelText(/Item 4 of 4: foobar005b4/);

--- a/test/Audio.spec.tsx
+++ b/test/Audio.spec.tsx
@@ -2,10 +2,10 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import audio from "test/fixtures/audio.json";
-import { WebchatMessage } from "src/messages/types";
+import { IMessage } from "@cognigy/socket-client";
 
 describe("Message Audio", () => {
-	const message = audio as unknown as WebchatMessage;
+	const message = audio as unknown as IMessage;
 
 	it("renders audio message", async () => {
 		await waitFor(() => {

--- a/test/Audio.spec.tsx
+++ b/test/Audio.spec.tsx
@@ -2,11 +2,14 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import audio from "test/fixtures/audio.json";
+import { WebchatMessage } from "src/messages/types";
 
 describe("Message Audio", () => {
+	const message = audio as unknown as WebchatMessage;
+
 	it("renders audio message", async () => {
 		await waitFor(() => {
-			render(<Message message={audio} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByTestId("audio-message")).toBeInTheDocument();
@@ -14,7 +17,7 @@ describe("Message Audio", () => {
 
 	it("renders audio message with custom skin controls", async () => {
 		await waitFor(() => {
-			render(<Message message={audio} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByTestId("audio-message").querySelector("audio")).not.toBeVisible();

--- a/test/Gallery.spec.tsx
+++ b/test/Gallery.spec.tsx
@@ -2,11 +2,14 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import gallery from "test/fixtures/gallery.json";
+import { WebchatMessage } from "src/messages/types";
 
 describe("Message Gallery", () => {
+	const message = gallery as unknown as WebchatMessage;
+
 	it("renders Gallery message", async () => {
 		await waitFor(() => {
-			render(<Message message={gallery} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByTestId("gallery-message")).toBeInTheDocument();
@@ -14,15 +17,15 @@ describe("Message Gallery", () => {
 
 	it("renders images inside gallery", async () => {
 		await waitFor(() => {
-			render(<Message message={gallery} />);
+			render(<Message message={message} />);
 		});
 
-		expect(screen.getAllByAltText("Attachment Image")).toHaveLength(7);
+		expect(screen.getAllByAltText("Attachment Image")).toHaveLength(8);
 	});
 
 	it("renders subtitles", async () => {
 		await waitFor(() => {
-			render(<Message message={gallery} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getAllByText(/foobar004g2/i)).toHaveLength(3);
@@ -30,7 +33,7 @@ describe("Message Gallery", () => {
 
 	it("renders with navigation arrows", async () => {
 		await waitFor(() => {
-			render(<Message message={gallery} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByLabelText("Next slide")).toBeVisible();
@@ -38,7 +41,7 @@ describe("Message Gallery", () => {
 
 	it("renders with pagination bullets", async () => {
 		await waitFor(() => {
-			render(<Message message={gallery} />);
+			render(<Message message={message} />);
 		});
 
 		expect(document.querySelector(".swiper-pagination")).toBeInTheDocument();

--- a/test/Gallery.spec.tsx
+++ b/test/Gallery.spec.tsx
@@ -2,10 +2,10 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import gallery from "test/fixtures/gallery.json";
-import { WebchatMessage } from "src/messages/types";
+import { IMessage } from "@cognigy/socket-client";
 
 describe("Message Gallery", () => {
-	const message = gallery as unknown as WebchatMessage;
+	const message = gallery as unknown as IMessage;
 
 	it("renders Gallery message", async () => {
 		await waitFor(() => {

--- a/test/Gallery.spec.tsx
+++ b/test/Gallery.spec.tsx
@@ -10,33 +10,33 @@ describe("Message Gallery", () => {
 		});
 
 		expect(screen.getByTestId("gallery-message")).toBeInTheDocument();
-    });
-    
-    it("renders images inside gallery", async () => {
+	});
+
+	it("renders images inside gallery", async () => {
 		await waitFor(() => {
 			render(<Message message={gallery} />);
 		});
 
 		expect(screen.getAllByAltText("Attachment Image")).toHaveLength(7);
-    });
-    
-    it("renders subtitles", async () => {
+	});
+
+	it("renders subtitles", async () => {
 		await waitFor(() => {
 			render(<Message message={gallery} />);
 		});
 
 		expect(screen.getAllByText(/foobar004g2/i)).toHaveLength(3);
-    });
-    
-    it("renders with navigation arrows", async () => {
+	});
+
+	it("renders with navigation arrows", async () => {
 		await waitFor(() => {
 			render(<Message message={gallery} />);
 		});
 
 		expect(screen.getByLabelText("Next slide")).toBeVisible();
-    });
-    
-    it("renders with pagination bullets", async () => {
+	});
+
+	it("renders with pagination bullets", async () => {
 		await waitFor(() => {
 			render(<Message message={gallery} />);
 		});

--- a/test/Image.spec.tsx
+++ b/test/Image.spec.tsx
@@ -9,11 +9,15 @@ import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import image from "test/fixtures/image.json";
 import imageDownloadable from "test/fixtures/image-downloadable.json";
+import { WebchatMessage } from "src/messages/types";
 
 describe("Message Image", () => {
+	const message = image as unknown as WebchatMessage;
+	const messageDownloadable = imageDownloadable as unknown as WebchatMessage;
+
 	it("renders image message", async () => {
 		await waitFor(() => {
-			render(<Message message={image} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByTestId("image-message")).toBeInTheDocument();
@@ -21,7 +25,7 @@ describe("Message Image", () => {
 
 	it("should have class 'webchat-media-template-image'", async () => {
 		await waitFor(() => {
-			render(<Message message={image} />);
+			render(<Message message={message} />);
 		});
 
 		expect(document.querySelector(".webchat-media-template-image")).toBeInTheDocument();
@@ -29,7 +33,7 @@ describe("Message Image", () => {
 
 	it("should not have role 'button' and aria-label", async () => {
 		await waitFor(() => {
-			render(<Message message={image} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.queryByRole("button")).not.toBeInTheDocument();
@@ -39,7 +43,7 @@ describe("Message Image", () => {
 	// Downloadable Image
 	it("should have role 'button' and aria-label", async () => {
 		await waitFor(() => {
-			render(<Message message={imageDownloadable} />);
+			render(<Message message={messageDownloadable} />);
 		});
 
 		expect(screen.queryByRole("button")).toBeInTheDocument();
@@ -49,7 +53,7 @@ describe("Message Image", () => {
 	// Lightbox
 	it("should open and close Lightbox with fullsize image", async () => {
 		await waitFor(() => {
-			render(<Message message={imageDownloadable} />);
+			render(<Message message={messageDownloadable} />);
 		});
 
 		fireEvent.click(screen.getByRole("button"));

--- a/test/Image.spec.tsx
+++ b/test/Image.spec.tsx
@@ -9,11 +9,11 @@ import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import image from "test/fixtures/image.json";
 import imageDownloadable from "test/fixtures/image-downloadable.json";
-import { WebchatMessage } from "src/messages/types";
+import { IMessage } from "@cognigy/socket-client";
 
 describe("Message Image", () => {
-	const message = image as unknown as WebchatMessage;
-	const messageDownloadable = imageDownloadable as unknown as WebchatMessage;
+	const message = image as unknown as IMessage;
+	const messageDownloadable = imageDownloadable as unknown as IMessage;
 
 	it("renders image message", async () => {
 		await waitFor(() => {

--- a/test/List.spec.tsx
+++ b/test/List.spec.tsx
@@ -2,11 +2,14 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import list from "test/fixtures/list.json";
+import { WebchatMessage } from "src/messages/types";
 
 describe("Message List", () => {
+	const message = list as unknown as WebchatMessage;
+
 	it("renders List message", async () => {
 		await waitFor(() => {
-			render(<Message message={list} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByTestId("list-message")).toBeInTheDocument();
@@ -14,7 +17,7 @@ describe("Message List", () => {
 
 	it("renders List message with large header", async () => {
 		await waitFor(() => {
-			render(<Message message={list} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByTestId("header-image")).toBeInTheDocument();
@@ -24,7 +27,7 @@ describe("Message List", () => {
 	it("renders top element of the list small", async () => {
 		list.data._cognigy._webchat.message.attachment.payload.top_element_style = "compact";
 		await waitFor(() => {
-			render(<Message message={list} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.queryByTestId("header-image")).not.toBeInTheDocument();
@@ -34,7 +37,7 @@ describe("Message List", () => {
 
 	it("renders 'global' button", async () => {
 		await waitFor(() => {
-			render(<Message message={list} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByText("Global Button")).toBeInTheDocument();
@@ -42,7 +45,7 @@ describe("Message List", () => {
 
 	it("should have static class names", async () => {
 		await waitFor(() => {
-			render(<Message message={list} />);
+			render(<Message message={message} />);
 		});
 
 		expect(document.querySelector(".webchat-list-template-root")).toBeInTheDocument();
@@ -66,7 +69,7 @@ describe("Message List", () => {
 
 	it("renders list and list items with correct roles", async () => {
 		await waitFor(() => {
-			render(<Message message={list} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByRole("list")).toBeInTheDocument();

--- a/test/List.spec.tsx
+++ b/test/List.spec.tsx
@@ -2,10 +2,10 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import list from "test/fixtures/list.json";
-import { WebchatMessage } from "src/messages/types";
+import { IMessage } from "@cognigy/socket-client";
 
 describe("Message List", () => {
-	const message = list as unknown as WebchatMessage;
+	const message = list as unknown as IMessage;
 
 	it("renders List message", async () => {
 		await waitFor(() => {

--- a/test/Message.spec.tsx
+++ b/test/Message.spec.tsx
@@ -1,11 +1,11 @@
 import { render } from "@testing-library/react";
 import { it, describe } from "vitest";
 import Message from "../src/messages/Message";
-import { WebchatMessage } from "src/messages/types";
+import { IMessage } from "@cognigy/socket-client";
 
 describe("Message", () => {
 	it("renders text message", () => {
-		const message = { text: "Hello World", source: "bot" } as WebchatMessage;
+		const message = { text: "Hello World", source: "bot" } as IMessage;
 
 		render(<Message message={message} />);
 	});

--- a/test/Message.spec.tsx
+++ b/test/Message.spec.tsx
@@ -1,10 +1,11 @@
 import { render } from "@testing-library/react";
 import { it, describe } from "vitest";
 import Message from "../src/messages/Message";
+import { WebchatMessage } from "src/messages/types";
 
 describe("Message", () => {
 	it("renders text message", () => {
-		const message = { text: "Hello World", source: "bot" };
+		const message = { text: "Hello World", source: "bot" } as WebchatMessage;
 
 		render(<Message message={message} />);
 	});

--- a/test/Video.spec.tsx
+++ b/test/Video.spec.tsx
@@ -8,10 +8,10 @@ import {
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import video from "test/fixtures/video.json";
-import { WebchatMessage } from "src/messages/types";
+import { IMessage } from "@cognigy/socket-client";
 
 describe("Message Video", () => {
-	const message = video as unknown as WebchatMessage;
+	const message = video as unknown as IMessage;
 
 	it("renders video message", async () => {
 		await waitFor(() => {

--- a/test/Video.spec.tsx
+++ b/test/Video.spec.tsx
@@ -8,11 +8,14 @@ import {
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import video from "test/fixtures/video.json";
+import { WebchatMessage } from "src/messages/types";
 
 describe("Message Video", () => {
+	const message = video as unknown as WebchatMessage;
+
 	it("renders video message", async () => {
 		await waitFor(() => {
-			render(<Message message={video} />);
+			render(<Message message={message} />);
 		});
 
 		expect(screen.getByTestId("video-message")).toBeInTheDocument();
@@ -20,7 +23,7 @@ describe("Message Video", () => {
 
 	it("renders video message in preview/poster mode", async () => {
 		await waitFor(() => {
-			render(<Message message={video} />);
+			render(<Message message={message} />);
 		});
 
 		expect(
@@ -30,7 +33,7 @@ describe("Message Video", () => {
 
 	it("on click the video is rendered replacing the preview", async () => {
 		await waitFor(() => {
-			render(<Message message={video} />);
+			render(<Message message={message} />);
 		});
 
 		expect(

--- a/test/fixtures/audio.json
+++ b/test/fixtures/audio.json
@@ -5,7 +5,7 @@
 			"_default": {
 				"_audio": {
 					"type": "audio",
-					"audioUrl": "https://www.winhistory.de/more/winstart/mp3/winxp.mp3"
+					"audioUrl": "https://download.samplelib.com/mp3/sample-15s.mp3"
 				}
 			},
 			"_webchat": {
@@ -13,7 +13,7 @@
 					"attachment": {
 						"type": "audio",
 						"payload": {
-							"url": "https://www.winhistory.de/more/winstart/mp3/winxp.mp3"
+							"url": "https://download.samplelib.com/mp3/sample-15s.mp3"
 						}
 					}
 				}

--- a/test/fixtures/gallery.json
+++ b/test/fixtures/gallery.json
@@ -47,7 +47,18 @@
 								{
 									"title": "Cat 1",
 									"image_url": "https://placekitten.com/300/300",
-									"buttons": null
+									"buttons": [
+										{
+											"type": "postback",
+											"payload": "sw",
+											"title": "foobar004g1b1"
+										},
+										{
+											"type": "postback",
+											"payload": "sw",
+											"title": "foobar004g1b2"
+										}
+									]
 								},
 								{
 									"title": "Cat 2",

--- a/test/fixtures/gallery.json
+++ b/test/fixtures/gallery.json
@@ -46,20 +46,8 @@
 							"elements": [
 								{
 									"title": "Cat 1",
-									"subtitle": "Deliver first class service experiences.",
 									"image_url": "https://placekitten.com/300/300",
-									"buttons": [
-										{
-											"type": "postback",
-											"payload": "sw",
-											"title": "foobar004g1b1"
-										},
-										{
-											"type": "postback",
-											"payload": "sw",
-											"title": "foobar004g1b2"
-										}
-									]
+									"buttons": null
 								},
 								{
 									"title": "Cat 2",
@@ -112,7 +100,11 @@
 									"title": "Cat 7",
 									"subtitle": "",
 									"image_url": "https://placekitten.com/300/300",
-									"buttons": []
+									"buttons": null
+								},
+								{
+									"title": "Cat 8",
+									"image_url": "https://placekitten.com/300/300"
 								}
 							]
 						}

--- a/test/fixtures/image-downloadable.json
+++ b/test/fixtures/image-downloadable.json
@@ -6,6 +6,7 @@
 				"_image": {
 					"type": "image",
 					"imageUrl": "https://placekitten.com/300/300",
+					"imageAltText": "",
 					"buttons": [
 						{
 							"type": "web_url",
@@ -21,6 +22,7 @@
 						"type": "image",
 						"payload": {
 							"url": "https://placekitten.com/300/300",
+							"altText": "",
 							"buttons": [
 								{
 									"type": "web_url",

--- a/test/matcher.spec.ts
+++ b/test/matcher.spec.ts
@@ -1,21 +1,21 @@
 import { it, describe, expect } from "vitest";
 import { match, MatchConfig } from "../src/matcher";
 import { createElement } from "react";
-import { WebchatMessage } from "../src/messages/types";
+import { IMessage } from "@cognigy/socket-client";
 
 describe("Message Matcher", () => {
 	it("matches text message", () => {
-		const message = { text: "Hello World" } as WebchatMessage;
+		const message = { text: "Hello World" } as IMessage;
 		const matchResult = match(message);
 		expect(matchResult?.name).toBe("Text");
 	});
 	it("matches nothing if unknown", () => {
-		const message = { text: null } as WebchatMessage;
+		const message = { text: null } as IMessage;
 		const matchResult = match(message);
 		expect(matchResult).toBe(null);
 	});
 	it("matches with custom config", () => {
-		const message = { text: null, data: { _cognigy: { _plugin: true } } } as WebchatMessage;
+		const message = { text: null, data: { _cognigy: { _plugin: true } } } as IMessage;
 		const config: MatchConfig[] = [
 			{
 				rule: message => !!message?.data?._cognigy?._plugin,

--- a/test/matcher.spec.ts
+++ b/test/matcher.spec.ts
@@ -1,23 +1,24 @@
 import { it, describe, expect } from "vitest";
 import { match, MatchConfig } from "../src/matcher";
 import { createElement } from "react";
+import { WebchatMessage } from "../src/messages/types";
 
 describe("Message Matcher", () => {
 	it("matches text message", () => {
-		const message = { text: "Hello World" };
+		const message = { text: "Hello World" } as WebchatMessage;
 		const matchResult = match(message);
 		expect(matchResult?.name).toBe("Text");
 	});
 	it("matches nothing if unknown", () => {
-		const message = { text: null, __bogus: {} };
+		const message = { text: null } as WebchatMessage;
 		const matchResult = match(message);
 		expect(matchResult).toBe(null);
 	});
 	it("matches with custom config", () => {
-		const message = { text: null, __plugin: true };
+		const message = { text: null, data: { _cognigy: { _plugin: true } } } as WebchatMessage;
 		const config: MatchConfig[] = [
 			{
-				rule: message => message.__plugin,
+				rule: message => !!message?.data?._cognigy?._plugin,
 				component: () => createElement("div", null),
 			},
 		];


### PR DESCRIPTION
This PRs includes a full refinement about types inference from SocketClient beta.5
It's also including an improvement on Audio components for Safari browser.
Changed also the Gallery fixture in order to have Items with null or undefined buttons, not just empty array
Updated devDeps and deps on package.json