### PR TITLE
Disabled postback in QR buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.4.0",
+			"version": "0.4.1",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"classnames": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
 	"files": [

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -8,7 +8,7 @@ import { sanitizeUrl } from "@braintree/sanitize-url";
 import classes from "./ActionButton.module.css";
 import { LinkIcon } from "src/assets/svg";
 
-interface ActionButtonProps extends React.HTMLAttributes<HTMLDivElement> {
+interface ActionButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
 	action?: ActionButtonsProps["action"];
 	className?: string;
 	button: ActionButtonsProps["payload"][number];
@@ -23,7 +23,7 @@ interface ActionButtonProps extends React.HTMLAttributes<HTMLDivElement> {
  * Postback, phone number, and URL buttons
  */
 const ActionButton: FC<ActionButtonProps> = props => {
-	const { button, total, position, showUrlIcon, customIcon } = props;
+	const { button, disabled, total, position, showUrlIcon, customIcon } = props;
 	const { config, onEmitAnalytics } = useMessageContext();
 
 	const buttonType =
@@ -51,7 +51,9 @@ const ActionButton: FC<ActionButtonProps> = props => {
 
 	const PhoneNumberAnchor = (props: React.HTMLAttributes<HTMLAnchorElement>) =>
 		button.payload ? <a {...props} href={`tel:${button.payload}`} /> : null;
-	const Button = (props: React.HTMLAttributes<HTMLButtonElement>) => <button {...props} />;
+	const Button = (props: React.HTMLAttributes<HTMLButtonElement>) => (
+		<button {...props} disabled={disabled} aria-disabled={disabled} />
+	);
 
 	const Component = isPhoneNumber ? PhoneNumberAnchor : Button;
 
@@ -72,7 +74,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 			return;
 		}
 
-		if (props.disabled) return;
+		if (disabled) return;
 
 		event.preventDefault();
 
@@ -91,10 +93,11 @@ const ActionButton: FC<ActionButtonProps> = props => {
 
 	return (
 		<Component
-			onClick={onClick}
-			className={classnames(classes.button, isWebURL && classes.url, props.className)}
-			role={isWebURL ? "link" : undefined}
 			aria-label={ariaLabel}
+			className={classnames(classes.button, isWebURL && classes.url, props.className)}
+			onClick={onClick}
+			aria-disabled={disabled}
+			role={isWebURL ? "link" : undefined}
 		>
 			<span dangerouslySetInnerHTML={{ __html }} />
 			{renderIcon()}

--- a/src/messages/Message.tsx
+++ b/src/messages/Message.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useMemo } from "react";
 import classnames from "classnames";
 
 import MessageHeader from "../common/MessageHeader";
@@ -16,6 +16,7 @@ export interface MessageProps {
 	className?: string;
 	config?: IWebchatConfig;
 	disableHeader?: boolean;
+	isLast?: boolean;
 	message: IMessage;
 	onEmitAnalytics?: (event: string, payload?: unknown) => void;
 	plugins?: MatchConfig[];
@@ -35,6 +36,8 @@ const Message: FC<MessageProps> = props => {
 
 	const MessageComponent = match(props.message, props.config, props.plugins);
 
+	const messageParams = useMemo(() => ({ isLast: props.isLast }), [props.isLast]);
+
 	/**
 	 * No rule matched the message, so we don't render anything.
 	 */
@@ -48,6 +51,7 @@ const Message: FC<MessageProps> = props => {
 			action={props.action}
 			onEmitAnalytics={props.onEmitAnalytics}
 			config={props.config}
+			messageParams={messageParams}
 		>
 			<article className={rootClassName}>
 				{!shouldCollate && <MessageHeader enableAvatar={props.message.source !== "user"} />}

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -14,19 +14,25 @@ import { IWebchatTemplateAttachment } from "@cognigy/socket-client";
  * they are same in Webchat v3
  */
 const TextWithButtons: FC = () => {
-	const { action, message, config } = useMessageContext();
+	const { action, message, config, messageParams } = useMessageContext();
 
 	const payload = getChannelPayload(message, config);
+
+	const isQuickReplies =
+		payload?.message?.quick_replies && payload.message.quick_replies.length > 0;
 
 	const attachments = payload?.message?.attachment as IWebchatTemplateAttachment;
 	const text = attachments?.payload?.text || payload?.message?.text || "";
 	const buttons = attachments?.payload?.buttons || payload?.message?.quick_replies || [];
 
+	const shouldBeDisabled = isQuickReplies && !messageParams?.isLast;
+	const modifiedAction = shouldBeDisabled ? undefined : action;
+
 	return (
 		<>
 			<Text content={text} />
 			<ActionButtons
-				action={action}
+				action={modifiedAction}
 				buttonClassName={classes.button}
 				containerClassName={classes.buttons}
 				payload={buttons}

--- a/src/messages/context.tsx
+++ b/src/messages/context.tsx
@@ -6,6 +6,9 @@ interface MessageProviderProps {
 	children: ReactNode;
 	config?: MessageProps["config"];
 	message: MessageProps["message"];
+	messageParams?: {
+		isLast: MessageProps["isLast"];
+	};
 	onEmitAnalytics?: MessageProps["onEmitAnalytics"];
 }
 
@@ -21,6 +24,7 @@ const MessageContext = createContext<MessageContextValue>(undefined);
  * - action
  * - onEmitAnalytics
  * - config
+ * - messageParams
  */
 const MessageProvider: FC<MessageProviderProps> = props => {
 	const { message, action, onEmitAnalytics, config } = props;

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,7 +1,7 @@
 :root {
 	--primary-color: var(--webchat-primary-color, #2455e6);
 	--primary-color-hover: color-mix(in srgb, var(--primary-color), #000 20%);
-	--primary-color-disabled: color-mix(in srgb, var(--primary-color), #fff 90%);
+	--primary-color-disabled: color-mix(in srgb, var(--primary-color), #fff 80%);
 	--primary-color-opacity-10: color-mix(in srgb, var(--primary-color) 10%, transparent);
 	--primary-color-opacity-20: color-mix(in srgb, var(--primary-color) 20%, transparent);
 


### PR DESCRIPTION
This add QR Buttons disabling logic. Postback QR Buttons get disabled if they are not the last message in history.

See Azure:[55714] as a reference. 


To test this PR:
- run `npm run dev` to see disabled buttons in demo
- check this PR in Webchat repo:
https://github.com/Cognigy/WebchatWidget/pull/345

