### PR TITLE
Feature/59952 file attachments output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"swiper": "^11.0.4"
 			},
 			"devDependencies": {
-				"@cognigy/socket-client": "^5.0.0-beta.10",
+				"@cognigy/socket-client": "5.0.0-beta.11",
 				"@testing-library/jest-dom": "^6.1.4",
 				"@testing-library/react": "^14.0.0",
 				"@types/dompurify": "^3.0.5",
@@ -612,9 +612,9 @@
 			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
 		},
 		"node_modules/@cognigy/socket-client": {
-			"version": "5.0.0-beta.10",
-			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-5.0.0-beta.10.tgz",
-			"integrity": "sha512-/Jv37T3MJ9qLOdqBfnW3wr0iPDTwxBc8QAuF5lKw+XpW0jlhi6hCvwj/fDGNxVZIyTO3XdZ73sr8BXKeiUASWA==",
+			"version": "5.0.0-beta.11",
+			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-5.0.0-beta.11.tgz",
+			"integrity": "sha512-rsfajzhsFfhnZh1o2KQpJO6xnoVayrdl0UxUGkpNntxhosdTYelMFnaiqVIPzdErlaD+Io3EgUuEKvS+3+G73w==",
 			"dev": true,
 			"dependencies": {
 				"detect-browser": "^4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.11.0",
+			"version": "0.12.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"swiper": "^11.0.4"
 			},
 			"devDependencies": {
-				"@cognigy/socket-client": "3.0.0-beta.12",
+				"@cognigy/socket-client": "5.0.0-beta.12",
 				"@testing-library/jest-dom": "^6.1.4",
 				"@testing-library/react": "^14.0.0",
 				"@types/dompurify": "^3.0.5",
@@ -612,9 +612,9 @@
 			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
 		},
 		"node_modules/@cognigy/socket-client": {
-			"version": "3.0.0-beta.12",
-			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-3.0.0-beta.12.tgz",
-			"integrity": "sha512-/MthCapcCNgJF1L+V9X1BRYR7IFEFu7X6OnlJ8ffsEBMjTcPuUY4BCXhjsoUaQ6dwUgpOFTEJKrlSdiDzRc+tw==",
+			"version": "5.0.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-5.0.0-beta.12.tgz",
+			"integrity": "sha512-0UArb13wECcD/bWdOsY93T32eYI1yC404JPPCt/fMAn+heh7/VzBtXUfEdK5aK/43nS7Z1oeO0JNvTYC3r/15Q==",
 			"dev": true,
 			"dependencies": {
 				"detect-browser": "^4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"swiper": "^11.0.4"
 			},
 			"devDependencies": {
-				"@cognigy/socket-client": "5.0.0-beta.11",
+				"@cognigy/socket-client": "3.0.0-beta.12",
 				"@testing-library/jest-dom": "^6.1.4",
 				"@testing-library/react": "^14.0.0",
 				"@types/dompurify": "^3.0.5",
@@ -612,9 +612,9 @@
 			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
 		},
 		"node_modules/@cognigy/socket-client": {
-			"version": "5.0.0-beta.11",
-			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-5.0.0-beta.11.tgz",
-			"integrity": "sha512-rsfajzhsFfhnZh1o2KQpJO6xnoVayrdl0UxUGkpNntxhosdTYelMFnaiqVIPzdErlaD+Io3EgUuEKvS+3+G73w==",
+			"version": "3.0.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-3.0.0-beta.12.tgz",
+			"integrity": "sha512-/MthCapcCNgJF1L+V9X1BRYR7IFEFu7X6OnlJ8ffsEBMjTcPuUY4BCXhjsoUaQ6dwUgpOFTEJKrlSdiDzRc+tw==",
 			"dev": true,
 			"dependencies": {
 				"detect-browser": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
 	"types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"test:watch": "vitest"
 	},
 	"devDependencies": {
-		"@cognigy/socket-client": "3.0.0-beta.12",
+		"@cognigy/socket-client": "5.0.0-beta.12",
 		"@testing-library/jest-dom": "^6.1.4",
 		"@testing-library/react": "^14.0.0",
 		"@types/dompurify": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"test:watch": "vitest"
 	},
 	"devDependencies": {
-		"@cognigy/socket-client": "5.0.0-beta.11",
+		"@cognigy/socket-client": "3.0.0-beta.12",
 		"@testing-library/jest-dom": "^6.1.4",
 		"@testing-library/react": "^14.0.0",
 		"@types/dompurify": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"test:watch": "vitest"
 	},
 	"devDependencies": {
-		"@cognigy/socket-client": "^5.0.0-beta.10",
+		"@cognigy/socket-client": "5.0.0-beta.11",
 		"@testing-library/jest-dom": "^6.1.4",
 		"@testing-library/react": "^14.0.0",
 		"@types/dompurify": "^3.0.5",

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -97,7 +97,7 @@ const defaultConfig: MatchConfig[] = [
 			const attachments = message?.data?.attachments;
 			if (!attachments) return false;
 
-			return attachments;
+			return true;
 		},
 		component: File,
 	},

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -93,7 +93,7 @@ const defaultConfig: MatchConfig[] = [
 	},
 	{
 		// File
-		rule: (message) => {
+		rule: message => {
 			const attachments = message?.data?.attachments;
 			if (!attachments) return false;
 

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -94,7 +94,6 @@ const defaultConfig: MatchConfig[] = [
 	{
 		// File
 		rule: (message) => {
-			// @ts-expect-error TODO:fix it in socket-client
 			const attachments = message?.data?.attachments;
 			if (!attachments) return false;
 

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -4,6 +4,7 @@ import {
 	Image,
 	Video,
 	Audio,
+	File,
 	List,
 	Gallery,
 	TextWithButtons,
@@ -89,6 +90,17 @@ const defaultConfig: MatchConfig[] = [
 			return channelConfig?.message?.attachment?.type === "audio";
 		},
 		component: Audio,
+	},
+	{
+		// File
+		rule: (message) => {
+			// @ts-expect-error TODO:fix it in socket-client
+			const attachments = message?.data?.attachments;
+			if (!attachments) return false;
+
+			return attachments;
+		},
+		component: File,
 	},
 	{
 		// List

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -26,9 +26,11 @@ const defaultConfig: MatchConfig[] = [
 		// Text message
 		rule: (message, config) => {
 			// do not render engagement messages unless configured!
+			// do not render messages with file attachments. It will be rendered by the File component
 			if (
-				message?.source === "engagement" &&
-				!config?.settings?.showEngagementMessagesInChat
+				(message?.source === "engagement" &&
+					!config?.settings?.showEngagementMessagesInChat) ||
+				message?.data?.attachments
 			) {
 				return false;
 			}

--- a/src/messages/File/File.module.css
+++ b/src/messages/File/File.module.css
@@ -22,16 +22,21 @@ article .filePreview {
 article .filePreview .fileNameWrapper {
 	display: flex;
 	flex-direction: row;
-	align-items: center;	
+	align-items: center;
 	max-width: 200px;
+	color: var(--black-10);
 }
 
-article .filePreview .fileNameWrapper .fileName {
+article .filePreview .fileName {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
 
-article .filePreview .fileNameWrapper .fileExtension {
+article .filePreview .fileExtension {
 	max-width: 60px;
+}
+
+article .filePreview .fileSize {
+	color: var(--black-40);
 }

--- a/src/messages/File/File.module.css
+++ b/src/messages/File/File.module.css
@@ -1,0 +1,39 @@
+article .filesWrapper {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+article:global(.user) .filesWrapper {
+	background: var(--background-user-message);
+	border-color: transparent;
+	margin-inline-start: auto;
+}
+
+article .filePreview {
+	display: flex;
+	gap: 12px;
+	padding: 8px 12px;
+	border-radius: 15px;
+	height: 33px;
+	background-color: var(--black-95);
+	max-width: 295px;
+}
+
+article .filePreview .fileNameWrapper {
+	display: flex;
+	flex-direction: row;
+	align-items: center;	
+	max-width: 200px;
+}
+
+article .filePreview .fileNameWrapper .fileName {
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+
+article .filePreview .fileNameWrapper .fileExtension {
+	max-width: 60px;
+}

--- a/src/messages/File/File.module.css
+++ b/src/messages/File/File.module.css
@@ -6,9 +6,7 @@ article .filesWrapper {
 }
 
 article:global(.user) .filesWrapper {
-	background: var(--background-user-message);
-	border-color: transparent;
-	margin-inline-start: auto;
+	justify-content: flex-end;
 }
 
 article .filePreview {

--- a/src/messages/File/File.tsx
+++ b/src/messages/File/File.tsx
@@ -26,36 +26,45 @@ const File: FC = () => {
 	return (
 		<div className={classnames(classes.filesWrapper, "webchat-media-files-template-root")}>
 			{attachments.map((attachment: IUploadFileMetaData, index: number) => {
-				const { fileName, size } = attachment;
+				const { fileName, size, url } = attachment;
 
 				return (
-					<div
-						className={classnames(classes.filePreview, "webchat-media-template-file")}
-						data-testid="file-message"
-						key={index}
-					>
-						<div className={classes.fileNameWrapper}>
+					<a href={url} target="_blank" style={{ textDecoration: "none" }}>
+						<div
+							className={classnames(
+								classes.filePreview,
+								"webchat-media-template-file",
+							)}
+							data-testid="file-message"
+							key={index}
+						>
+							<div className={classes.fileNameWrapper}>
+								<Typography
+									component="span"
+									variant="title2-regular"
+									className={classes.fileName}
+								>
+									{getFileName(fileName)}
+								</Typography>
+								<Typography
+									component="span"
+									variant="title2-regular"
+									className={classes.fileExtension}
+								>
+									{getFileExtension(fileName)}
+								</Typography>
+							</div>
 							<Typography
 								component="span"
 								variant="title2-regular"
-								className={classes.fileName}
+								className={classes.fileSize}
 							>
-								{getFileName(fileName)}
-							</Typography>
-							<Typography
-								component="span"
-								variant="title2-regular"
-								className={classes.fileExtension}
-							>
-								{getFileExtension(fileName)}
+								{size > 1000000
+									? `${(size / 1000000).toFixed(2)} MB`
+									: `${(size / 1000).toFixed(2)} KB`}
 							</Typography>
 						</div>
-						<Typography component="span" variant="title2-regular">
-							{size > 1000000
-								? `${(size / 1000000).toFixed(2)} MB`
-								: `${(size / 1000).toFixed(2)} KB`}
-						</Typography>
-					</div>
+					</a>
 				);
 			})}
 		</div>

--- a/src/messages/File/File.tsx
+++ b/src/messages/File/File.tsx
@@ -19,8 +19,6 @@ const File: FC = () => {
 	// @ts-expect-error TODO:fix it in socket-client
 	const attachments = message.data?.attachments as IUploadFileMetaData[];
 
-	console.log("attachments", attachments);
-
 	if (!attachments || attachments.length === 0) return null;
 
 	return (

--- a/src/messages/File/File.tsx
+++ b/src/messages/File/File.tsx
@@ -4,6 +4,7 @@ import classnames from "classnames";
 import { IUploadFileAttachmentData } from "@cognigy/socket-client";
 import { useMessageContext } from "src/messages/hooks";
 import { Typography } from "src/index";
+import { Text } from "src/messages";
 import { getFileExtension, getFileName } from "./helper";
 
 const File: FC = () => {
@@ -13,50 +14,53 @@ const File: FC = () => {
 	if (!attachments || attachments.length === 0) return null;
 
 	return (
-		<div className={classnames(classes.filesWrapper, "webchat-media-files-template-root")}>
-			{attachments.map((attachment: IUploadFileAttachmentData, index: number) => {
-				const { fileName, size, url } = attachment;
+		<>
+			{message.text && <Text content={message.text} />}
+			<div className={classnames(classes.filesWrapper, "webchat-media-files-template-root")}>
+				{attachments.map((attachment: IUploadFileAttachmentData, index: number) => {
+					const { fileName, size, url } = attachment;
 
-				return (
-					<a href={url} target="_blank" style={{ textDecoration: "none" }}>
-						<div
-							className={classnames(
-								classes.filePreview,
-								"webchat-media-template-file",
-							)}
-							data-testid="file-message"
-							key={index}
-						>
-							<div className={classes.fileNameWrapper}>
+					return (
+						<a href={url} target="_blank" style={{ textDecoration: "none" }}>
+							<div
+								className={classnames(
+									classes.filePreview,
+									"webchat-media-template-file",
+								)}
+								data-testid="file-message"
+								key={index}
+							>
+								<div className={classes.fileNameWrapper}>
+									<Typography
+										component="span"
+										variant="title2-regular"
+										className={classes.fileName}
+									>
+										{getFileName(fileName)}
+									</Typography>
+									<Typography
+										component="span"
+										variant="title2-regular"
+										className={classes.fileExtension}
+									>
+										{getFileExtension(fileName)}
+									</Typography>
+								</div>
 								<Typography
 									component="span"
 									variant="title2-regular"
-									className={classes.fileName}
+									className={classes.fileSize}
 								>
-									{getFileName(fileName)}
-								</Typography>
-								<Typography
-									component="span"
-									variant="title2-regular"
-									className={classes.fileExtension}
-								>
-									{getFileExtension(fileName)}
+									{size > 1000000
+										? `${(size / 1000000).toFixed(2)} MB`
+										: `${(size / 1000).toFixed(2)} KB`}
 								</Typography>
 							</div>
-							<Typography
-								component="span"
-								variant="title2-regular"
-								className={classes.fileSize}
-							>
-								{size > 1000000
-									? `${(size / 1000000).toFixed(2)} MB`
-									: `${(size / 1000).toFixed(2)} KB`}
-							</Typography>
-						</div>
-					</a>
-				);
-			})}
-		</div>
+						</a>
+					);
+				})}
+			</div>
+		</>
 	);
 };
 

--- a/src/messages/File/File.tsx
+++ b/src/messages/File/File.tsx
@@ -1,0 +1,65 @@
+import { FC } from "react";
+import classes from "./File.module.css";
+import classnames from "classnames";
+import { useMessageContext } from "src/messages/hooks";
+import { Typography } from "src/index";
+import { getFileExtension, getFileName } from "./helper";
+
+export interface IUploadFileMetaData {
+	runtimeFileId: string;
+	fileName: string;
+	status?: "infected" | "scanned";
+	mimeType: string;
+	size: number;
+	url: string;
+}
+
+const File: FC = () => {
+	const { message } = useMessageContext();
+	// @ts-expect-error TODO:fix it in socket-client
+	const attachments = message.data?.attachments as IUploadFileMetaData[];
+
+	console.log("attachments", attachments);
+
+	if (!attachments || attachments.length === 0) return null;
+
+	return (
+		<div className={classnames(classes.filesWrapper, "webchat-media-files-template-root")}>
+			{attachments.map((attachment: IUploadFileMetaData, index: number) => {
+				const { fileName, size } = attachment;
+
+				return (
+					<div
+						className={classnames(classes.filePreview, "webchat-media-template-file")}
+						data-testid="file-message"
+						key={index}
+					>
+						<div className={classes.fileNameWrapper}>
+							<Typography
+								component="span"
+								variant="title2-regular"
+								className={classes.fileName}
+							>
+								{getFileName(fileName)}
+							</Typography>
+							<Typography
+								component="span"
+								variant="title2-regular"
+								className={classes.fileExtension}
+							>
+								{getFileExtension(fileName)}
+							</Typography>
+						</div>
+						<Typography component="span" variant="title2-regular">
+							{size > 1000000
+								? `${(size / 1000000).toFixed(2)} MB`
+								: `${(size / 1000).toFixed(2)} KB`}
+						</Typography>
+					</div>
+				);
+			})}
+		</div>
+	);
+};
+
+export default File;

--- a/src/messages/File/File.tsx
+++ b/src/messages/File/File.tsx
@@ -1,29 +1,20 @@
 import { FC } from "react";
 import classes from "./File.module.css";
 import classnames from "classnames";
+import { IUploadFileAttachmentData } from "@cognigy/socket-client";
 import { useMessageContext } from "src/messages/hooks";
 import { Typography } from "src/index";
 import { getFileExtension, getFileName } from "./helper";
 
-export interface IUploadFileMetaData {
-	runtimeFileId: string;
-	fileName: string;
-	status?: "infected" | "scanned";
-	mimeType: string;
-	size: number;
-	url: string;
-}
-
 const File: FC = () => {
 	const { message } = useMessageContext();
-	// @ts-expect-error TODO:fix it in socket-client
-	const attachments = message.data?.attachments as IUploadFileMetaData[];
+	const attachments = message.data?.attachments as IUploadFileAttachmentData[];
 
 	if (!attachments || attachments.length === 0) return null;
 
 	return (
 		<div className={classnames(classes.filesWrapper, "webchat-media-files-template-root")}>
-			{attachments.map((attachment: IUploadFileMetaData, index: number) => {
+			{attachments.map((attachment: IUploadFileAttachmentData, index: number) => {
 				const { fileName, size, url } = attachment;
 
 				return (

--- a/src/messages/File/helper.ts
+++ b/src/messages/File/helper.ts
@@ -1,7 +1,7 @@
 export const getFileName = (fileNameWithExtension: string) => {
-	const splitName = fileNameWithExtension.split('.');
+	const splitName = fileNameWithExtension.split(".");
 	if (splitName.length > 1) {
-		return `${splitName.slice(0, -1).join('.')}.`;
+		return `${splitName.slice(0, -1).join(".")}.`;
 	} else {
 		// return full name here if it didn't have a file ending
 		return fileNameWithExtension;
@@ -9,7 +9,7 @@ export const getFileName = (fileNameWithExtension: string) => {
 };
 
 export const getFileExtension = (fileNameWithExtension: string) => {
-	const splitName = fileNameWithExtension.split('.');
+	const splitName = fileNameWithExtension.split(".");
 	if (splitName.length > 1) {
 		return splitName.pop();
 	} else {

--- a/src/messages/File/helper.ts
+++ b/src/messages/File/helper.ts
@@ -1,0 +1,18 @@
+export const getFileName = (fileNameWithExtension: string) => {
+	const splitName = fileNameWithExtension.split('.');
+	if (splitName.length > 1) {
+		return `${splitName.slice(0, -1).join('.')}.`;
+	} else {
+		// return full name here if it didn't have a file ending
+		return fileNameWithExtension;
+	}
+};
+
+export const getFileExtension = (fileNameWithExtension: string) => {
+	const splitName = fileNameWithExtension.split('.');
+	if (splitName.length > 1) {
+		return splitName.pop();
+	} else {
+		return null;
+	}
+};

--- a/src/messages/File/index.ts
+++ b/src/messages/File/index.ts
@@ -1,0 +1,3 @@
+import File from "./File";
+
+export default File;

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -2,10 +2,11 @@ import Text from "./Text";
 import Image from "./Image";
 import Video from "./Video";
 import Audio from "./Audio";
+import File from "./File";
 import List from "./List";
 import Gallery from "./Gallery";
 import DatePicker from "./DatePicker";
 import TextWithButtons from "./TextWithButtons/TextWithButtons";
 import { AdaptiveCards as AdaptiveCard } from "./AdaptiveCards";
 
-export { Text, Image, Video, Audio, List, Gallery, DatePicker, TextWithButtons, AdaptiveCard };
+export { Text, Image, Video, Audio, File, List, Gallery, DatePicker, TextWithButtons, AdaptiveCard };

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -9,4 +9,15 @@ import DatePicker from "./DatePicker";
 import TextWithButtons from "./TextWithButtons/TextWithButtons";
 import { AdaptiveCards as AdaptiveCard } from "./AdaptiveCards";
 
-export { Text, Image, Video, Audio, File, List, Gallery, DatePicker, TextWithButtons, AdaptiveCard };
+export {
+	Text,
+	Image,
+	Video,
+	Audio,
+	File,
+	List,
+	Gallery,
+	DatePicker,
+	TextWithButtons,
+	AdaptiveCard,
+};

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -106,6 +106,13 @@ const screens: TScreen[] = [
 					timestamp: "1701163314138",
 				},
 			},
+			{ 
+				message: {...file, timestamp: "1701163314138", source: "user"} as IMessage,
+				prevMessage: {
+					source: "bot",
+					timestamp: "1701163314138",
+				},
+			},
 		],
 		content: [<TypingIndicator />, <ChatEvent text="Conversation started" />],
 	},
@@ -132,7 +139,6 @@ const screens: TScreen[] = [
 			{ message: video as IMessage },
 			{ message: videoYoutube as IMessage },
 			{ message: audio as IMessage },
-			{ message: file as IMessage}
 		],
 	},
 	{

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -106,8 +106,8 @@ const screens: TScreen[] = [
 					timestamp: "1701163314138",
 				},
 			},
-			{ 
-				message: {...file, timestamp: "1701163314138", source: "user"} as IMessage,
+			{
+				message: { ...file, timestamp: "1701163314138", source: "user" } as IMessage,
 				prevMessage: {
 					source: "bot",
 					timestamp: "1701163314138",

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -14,6 +14,7 @@ import imageBroken from "test/fixtures/imageBroken.json";
 import video from "test/fixtures/video.json";
 import videoYoutube from "test/fixtures/videoYoutube.json";
 import audio from "test/fixtures/audio.json";
+import file from "test/fixtures/file.json";
 import AdaptiveCardPayloads from "test/fixtures/adaptiveCards.json";
 
 import datePicker from "test/fixtures/datepicker/singleDate.json";
@@ -131,6 +132,7 @@ const screens: TScreen[] = [
 			{ message: video as IMessage },
 			{ message: videoYoutube as IMessage },
 			{ message: audio as IMessage },
+			{ message: file as IMessage}
 		],
 	},
 	{

--- a/test/fixtures/file.json
+++ b/test/fixtures/file.json
@@ -2,22 +2,22 @@
 	"text": null,
 	"data": {
 		"attachments": [
-            {
-                "runtimeFileId": "1234",
-                "mimeType": "application/pdf",
-                "size": 893,
-                "status": "scanned",
-                "url": "https://www.africau.edu/images/default/sample.pdf",
-                "fileName": "sample.pdf"
-            },
-            {
-                "runtimeFileId": "12345",
-                "mimeType": "image/png",
-                "size": 118256,
-                "status": "scanned",
-                "url": "https://placekitten.com/300/300",
-                "fileName": "Screenshot from 2024-01-24 10-28-43 - overflow.png"
-            }
-        ]
+			{
+				"runtimeFileId": "1234",
+				"mimeType": "application/pdf",
+				"size": 893,
+				"status": "scanned",
+				"url": "https://www.africau.edu/images/default/sample.pdf",
+				"fileName": "sample.pdf"
+			},
+			{
+				"runtimeFileId": "12345",
+				"mimeType": "image/png",
+				"size": 118256,
+				"status": "scanned",
+				"url": "https://placekitten.com/300/300",
+				"fileName": "Screenshot from 2024-01-24 10-28-43 - overflow.png"
+			}
+		]
 	}
 }

--- a/test/fixtures/file.json
+++ b/test/fixtures/file.json
@@ -1,0 +1,23 @@
+{
+	"text": null,
+	"data": {
+		"attachments": [
+            {
+                "runtimeFileId": "1234",
+                "mimeType": "application/pdf",
+                "size": 893,
+                "status": "scanned",
+                "url": "https://www.africau.edu/images/default/sample.pdf",
+                "fileName": "sample.pdf"
+            },
+            {
+                "runtimeFileId": "12345",
+                "mimeType": "image/png",
+                "size": 118256,
+                "status": "scanned",
+                "url": "https://placekitten.com/300/300",
+                "fileName": "Screenshot from 2024-01-24 10-28-43 - overflow.png"
+            }
+        ]
+	}
+}

--- a/test/fixtures/file.json
+++ b/test/fixtures/file.json
@@ -1,5 +1,5 @@
 {
-	"text": null,
+	"text": "Here are the attachments you requested.",
 	"data": {
 		"attachments": [
 			{


### PR DESCRIPTION
Thus PR adds the chat components needed to display the file attachment outputs

NOTE: Please also review the PR is socket client repo before this https://github.com/Cognigy/SocketClient/pull/33

- Please check if the UI is same as the Figma prototypes
- If a file has a long name, then it will be replaced with ellipsis
- You should be able to click the file and open it in new browser tab
- To test: Check the file attachment output sample added to UI components tab of the chat components demo. Also, test by packing the chat-components and installing it in Webchat widget.

