### PR TITLE
Fix building in webpack with babel-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.17.0",
+	"version": "0.17.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.17.0",
+			"version": "0.17.1",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.18",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.17.0",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
+	"module": "./dist/chat-components.js",
 	"types": "./dist/index.d.ts",
 	"files": [
 		"./dist/**/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.17.0",
+	"version": "0.17.1",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
 	"module": "./dist/chat-components.js",


### PR DESCRIPTION
This PR fixes an issue with usage of chat-components in the build pipeline with Webpack and babel-loader.