### PR TITLE
Fix agent message header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.19.0",
+	"version": "0.19.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.19.0",
+			"version": "0.19.1",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.19.0",
+	"version": "0.19.1",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
 	"module": "./dist/chat-components.js",

--- a/src/common/MessageHeader.tsx
+++ b/src/common/MessageHeader.tsx
@@ -20,6 +20,7 @@ const MessageHeader: FC<MessageHeaderProps> = props => {
 	const { message } = useMessageContext();
 
 	const isUserMessage = message.source === "user";
+	const isAgentMessage = message.source === "agent";
 
 	const className = classnames(
 		"message-header",
@@ -37,7 +38,7 @@ const MessageHeader: FC<MessageHeaderProps> = props => {
 				{!isUserMessage && (
 					<>
 						<span className={classes["avatar-name"]}>
-							{message?.avatarName || "Bot"}
+							{message?.avatarName || (isAgentMessage ? "Agent" : "Bot")}
 						</span>
 						<HeaderEllipsis />
 					</>

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -96,6 +96,13 @@ const screens: TScreen[] = [
 					timestamp: "1701163314138",
 				},
 			},
+			{
+				message: {
+					text: "This message has a new a header",
+					source: "agent",
+					timestamp: "1701163314138",
+				},
+			},
 		],
 	},
 	{


### PR DESCRIPTION
Fixes the issue that an agent message can be displayed with the header label "Bot" if nothing else is configured for the endpoint
https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/63404

Reproduce: 
- have endpoint without any webchat name configured (nor bot name/agent name)
- connect to handover
- send message from agent