### PR TITLE
Bug/63110 fix urls in text message

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,8 @@ export const getRandomId = (prefix = "") => {
  */
 export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
-	const urlMatcherRegex = /(^|\s)(\b(https?):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/gi;
+	const urlMatcherRegex =
+		/(^|\s)(\b(https?):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/gi;
 
 	if (typeof text !== "string") return text;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,7 @@ export const getRandomId = (prefix = "") => {
  */
 export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
-	const urlMatcherRegex = /(\b(https?):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/gi;
+	const urlMatcherRegex = /(^|\s)(\b(https?):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/gi;
 
 	if (typeof text !== "string") return text;
 

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -286,6 +286,12 @@ const screens: TScreen[] = [
 					text: "This message should not overflow and should get hard breaks: https://static.test?token=d4567f11cffa23a49b2190355b956da8de46fcbc7817d3ce3708d6bddabc0bfd",
 				},
 			},
+			{
+				message: {
+					source: "bot",
+					text: 'This message has both anchor and image tags <a href="https://docs.cognigy.com">Cognigy Docs</a> <img src="https://placekitten.com/200/200" alt="Alt text">',
+				},
+			},
 		],
 	},
 	{


### PR DESCRIPTION
This PR fixes the regex to match the links in messages. 

Success Criteria:
- If there is a HTML anchor tag in a message, then the link should be properly displayed inside the message bubble
- If thers is a HTML image tag in a message, then the image should be correctly displayed in the message bubble

How to test:
- Create a flow with a Say node, that includes an anchor and image tags
- Check the success criteria