### PR TITLE
Fix Autofocus after Postback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.26.0",
+	"version": "0.27.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.26.0",
+			"version": "0.27.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.26.0",
+	"version": "0.27.0",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
 	"module": "./dist/chat-components.js",

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -103,7 +103,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		event.preventDefault();
 
 		const textMessageInput = document.getElementById("webchatInputMessageInputInTextMode");
-		if (textMessageInput && config?.settings?.widgetSettings?.enableAutoFocus) {
+		if (textMessageInput && config?.settings?.behavior?.focusInputAfterPostback) {
 			textMessageInput.focus?.();
 		}
 


### PR DESCRIPTION
This PR fixes an issue where, when configured, the text input still would not get focus after the user click a Quick Reply