### PR TITLE
Add label for month and year inputs

### DIFF
--- a/src/messages/DatePicker/DatePicker.module.css
+++ b/src/messages/DatePicker/DatePicker.module.css
@@ -226,6 +226,14 @@
 	font-size: 14px;
 }
 
+.wrapper .content :global(.flatpickr-current-month) label {
+	color: var(--cc-black-40);
+	position: absolute;
+	top: -15px;
+	padding-left: 6px;
+	font-size: 12px;
+}
+
 .wrapper .content :global(.flatpickr-current-month .flatpickr-monthDropdown-months::-ms-expand) {
 	display: none;
 }

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -133,11 +133,11 @@ function customElements(pluginConfig: Config): Plugin {
 				upsertTimeArrows,
 				buildTimeArrows,
 				setTimeAlly,
+				setMonthSelectAlly,
+				setYearSelectAlly,
 				() => {
 					fp?.loadedPlugins?.push("customElements");
 				},
-				setMonthSelectAlly,
-				setYearSelectAlly,
 			],
 			onDayCreate: [
 				(_dObj, _dStr, _fp, dayElem) => {

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -89,6 +89,45 @@ function customElements(pluginConfig: Config): Plugin {
 			}
 		}
 
+		function setMonthSelectAlly() {
+			const monthYearDiv =
+				fp?.calendarContainer?.getElementsByClassName("flatpickr-current-month")[0];
+
+			const monthSelector = monthYearDiv?.getElementsByClassName(
+				"flatpickr-monthDropdown-months",
+			)?.[0] as HTMLElement;
+			monthSelector?.setAttribute("id", "monthSelector-datepicker");
+			monthSelector?.classList.add("monthSelector-datepicker");
+			// unset aria-label attribute from month input to avaoid redundancy
+			monthSelector?.removeAttribute("aria-label");
+
+			const monthLabel = document.createElement("label");
+			monthLabel.setAttribute("for", "monthSelector-datepicker");
+
+			monthLabel.textContent = "Month";
+
+			monthYearDiv?.prepend(monthLabel);
+		}
+
+		function setYearSelectAlly() {
+			const monthYearDiv =
+				fp?.calendarContainer?.getElementsByClassName("flatpickr-current-month")[0];
+
+			const yearInput = monthYearDiv?.getElementsByClassName("cur-year")?.[0] as HTMLElement;
+
+			const yearInputWrapper = yearInput?.parentElement as HTMLElement;
+			yearInput?.setAttribute("id", "yearSelector-datepicker");
+			yearInput?.classList.add("yearSelector-datepicker");
+			// unset aria-label attribute from year input to avaoid redundancy
+			yearInput?.removeAttribute("aria-label");
+
+			const yearLabel = document.createElement("label");
+			yearLabel.setAttribute("for", "yearSelector-datepicker");
+			yearLabel.textContent = "Year";
+
+			yearInputWrapper?.prepend(yearLabel);
+		}
+
 		return {
 			onReady: [
 				upsertTimeArrows,
@@ -97,6 +136,8 @@ function customElements(pluginConfig: Config): Plugin {
 				() => {
 					fp?.loadedPlugins?.push("customElements");
 				},
+				setMonthSelectAlly,
+				setYearSelectAlly,
 			],
 			onDayCreate: [
 				(_dObj, _dStr, _fp, dayElem) => {


### PR DESCRIPTION
This PR adds a visible label to month and year input field inside date picker 

Open date picker and check if the month and year fields have labels