### PR TITLE
Fix audio slider a11y issues

### DIFF
--- a/src/messages/Audio/Controls.tsx
+++ b/src/messages/Audio/Controls.tsx
@@ -51,6 +51,18 @@ const Controls: FC<ControlsProps> = props => {
 		return `${mm}:${ss}`;
 	};
 
+	// Convert formatted time to readable text for screen readers
+	const timeToText = (time: string) => {
+		if (time.length < 6) {
+			time = `00:${time}`;
+		}
+		const [hours, minutes, seconds] = time.split(":").map(Number);
+		const hoursText = hours ? `${hours} hours ` : "";
+		const minutesText = minutes ? `${minutes} minutes ` : "";
+		const secondsText = `${seconds} seconds`;
+		return `${hoursText}${minutesText}${secondsText}`;
+	};
+
 	return (
 		<div className={classes.controls} data-testid="audio-controls">
 			<div className="duration">
@@ -64,6 +76,8 @@ const Controls: FC<ControlsProps> = props => {
 					max={0.999999}
 					step="any"
 					value={progress}
+					aria-valuetext={`${timeToText(formatTime())} remaining`}
+					aria-label="Audio progress bar"
 					onMouseDown={handleSeekStart}
 					onTouchStart={handleSeekStart}
 					onChange={handleSeekChange}

--- a/src/messages/Audio/Controls.tsx
+++ b/src/messages/Audio/Controls.tsx
@@ -77,7 +77,7 @@ const Controls: FC<ControlsProps> = props => {
 					step="any"
 					value={progress}
 					aria-valuetext={`${timeToText(formatTime())} remaining`}
-					aria-label="Audio progress bar"
+					aria-label="Audio playback progress"
 					onMouseDown={handleSeekStart}
 					onTouchStart={handleSeekStart}
 					onChange={handleSeekChange}

--- a/src/messages/Audio/Controls.tsx
+++ b/src/messages/Audio/Controls.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, MutableRefObject } from "react";
+import { ChangeEvent, FC, MutableRefObject, useMemo } from "react";
 import classes from "./Audio.module.css";
 import { AudioPause, AudioPlay } from "src/assets/svg";
 import ReactPlayer from "react-player";
@@ -35,7 +35,7 @@ const Controls: FC<ControlsProps> = props => {
 		handlePlay();
 	};
 
-	const formatTime = () => {
+	const formatTime = useMemo(() => {
 		const padString = (string: number) => {
 			return ("0" + string).slice(-2);
 		};
@@ -49,7 +49,7 @@ const Controls: FC<ControlsProps> = props => {
 			return `${hh}:${padString(mm)}:${ss}`;
 		}
 		return `${mm}:${ss}`;
-	};
+	}, [duration, progress]);
 
 	// Convert formatted time to readable text for screen readers
 	const timeToText = (time: string) => {
@@ -66,7 +66,7 @@ const Controls: FC<ControlsProps> = props => {
 	return (
 		<div className={classes.controls} data-testid="audio-controls">
 			<div className="duration">
-				<time>{formatTime()}</time>
+				<time>{formatTime}</time>
 			</div>
 
 			<div className={classes.progressBar}>
@@ -76,7 +76,7 @@ const Controls: FC<ControlsProps> = props => {
 					max={0.999999}
 					step="any"
 					value={progress}
-					aria-valuetext={`${timeToText(formatTime())} remaining`}
+					aria-valuetext={`${timeToText(formatTime)} remaining`}
 					aria-label="Audio playback progress"
 					onMouseDown={handleSeekStart}
 					onTouchStart={handleSeekStart}


### PR DESCRIPTION
This PR makes the slider control in the audio message accessible.

- Check if the slider input has a meaningful aria-label
- Check if the aria-valuetext attribute has the remaining playback time of the audio

Already tested:
- Tested if the aria-valuetext is read out by NVDA screen reader in windows.