### PR TITLE
Change default text link color to make it accessible

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -20,7 +20,7 @@
 		var(--cc-background-bot-message)
 	);
 
-	--cc-text-link: var(--webchat-text-link, #6688ed);
+	--cc-text-link: var(--webchat-text-link, #335fdf);
 	--cc-text-link-hover: color-mix(in srgb, var(--cc-text-link), #000 20%);
 	--cc-text-link-disabled: color-mix(in srgb, var(--cc-text-link), #fff 90%);
 


### PR DESCRIPTION
This PR changes the default color of text links in message bubbles to have enough color contrast with the default bot message bubble background color.

- Check the link text color in message bubbles