### PR TITLE
Feature/75381 carousal dot color contrast

### DIFF
--- a/src/messages/Gallery/Gallery.module.css
+++ b/src/messages/Gallery/Gallery.module.css
@@ -176,7 +176,7 @@ article :global(.swiper).wrapper :global(.swiper-pagination-bullet) {
 	height: 6px;
 	display: inline-block;
 	border-radius: 50%;
-	background: var(--cc-black-80);
+	background: var(--cc-black-50);
 	opacity: 1;
 }
 article :global(.swiper).wrapper :global(.swiper-pagination-bullet):focus {

--- a/src/theme.css
+++ b/src/theme.css
@@ -28,7 +28,7 @@
 	--cc-black-20: #333;
 	--cc-black-30: #4d4d4d;
 	--cc-black-40: #666;
-	--cc-black-50: #757575;
+	--cc-black-50: #808080;
 	--cc-black-60: #999;
 	--cc-black-80: #ccc;
 	--cc-black-90: #e5e5e5;

--- a/src/theme.css
+++ b/src/theme.css
@@ -28,6 +28,7 @@
 	--cc-black-20: #333;
 	--cc-black-30: #4d4d4d;
 	--cc-black-40: #666;
+	--cc-black-50: #757575;
 	--cc-black-60: #999;
 	--cc-black-80: #ccc;
 	--cc-black-90: #e5e5e5;


### PR DESCRIPTION
This PR changes the color of carousal dots to maintain enough color contrast with the default chat background

- The new corousal dot color should meet or exceed 3:1 contrast ratio with the chat background 
![Screenshot from 2024-08-19 18-55-08](https://github.com/user-attachments/assets/dfa27cec-02d6-42f2-9eae-3bbe381d5e8d)
