### PR TITLE
Hide message bubble when text is empty

### DIFF
--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -40,11 +40,11 @@ const TextWithButtons: FC = () => {
 
 	return (
 		<div className={`webchat-${classType}-template-root`}>
-			<Text
+			{text && <Text
 				content={text}
 				className={`webchat-${classType}-template-header`}
 				id={webchatButtonTemplateTextId}
-			/>
+			/>}
 
 			<ActionButtons
 				action={modifiedAction}

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -40,11 +40,13 @@ const TextWithButtons: FC = () => {
 
 	return (
 		<div className={`webchat-${classType}-template-root`}>
-			{text && <Text
-				content={text}
-				className={`webchat-${classType}-template-header`}
-				id={webchatButtonTemplateTextId}
-			/>}
+			{text && (
+				<Text
+					content={text}
+					className={`webchat-${classType}-template-header`}
+					id={webchatButtonTemplateTextId}
+				/>
+			)}
 
 			<ActionButtons
 				action={modifiedAction}

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -209,6 +209,36 @@ const screens: TScreen[] = [
 			{
 				message: {
 					avatarName: "Cognigy",
+					text: "",
+					source: "bot",
+					data: {
+						_cognigy: {
+							_webchat: {
+								message: {
+									text: "",
+									quick_replies: [
+										{
+											content_type: "text",
+											payload: "payload1",
+											title: "This QR does not have a text bubble above",
+										},
+										{
+											content_type: "user_phone_number",
+											image_url: "",
+											image_alt_text: "",
+											payload: "0111222333",
+											title: "Call us",
+										},
+									],
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				message: {
+					avatarName: "Cognigy",
 					source: "bot",
 
 					data: {


### PR DESCRIPTION
This PR fixes as issue where an empty message bubble was rendered when the text of the QR template is empty.

# Test 
- See the example on Demo page

https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/75384/