### PR TITLE
Add slide number as aria label to carousal items

### DIFF
--- a/src/messages/Gallery/Gallery.tsx
+++ b/src/messages/Gallery/Gallery.tsx
@@ -59,6 +59,7 @@ const Gallery: FC = () => {
 			pagination={{ clickable: true }}
 			className={classnames("webchat-carousel-template-root", classes.wrapper)}
 			data-testid="gallery-message"
+			a11y={{ slideLabelMessage: `Slide {{index}} of {{slidesLength}}` }}
 		>
 			{elements.map((element: IWebchatAttachmentElement, i: number) => (
 				<SwiperSlide key={i} style={{ width: "206px" }}>


### PR DESCRIPTION
This PR improves the aria-label of carousal slides

- Aria label of a slide in the carousal should be clear like 'Slide 1 of 3'. Previously it was 1/3.