### PR TITLE
Bug/fix image keyboard a11y

### DIFF
--- a/src/messages/Image/Image.module.css
+++ b/src/messages/Image/Image.module.css
@@ -6,9 +6,13 @@ article .wrapper {
 	outline: none;
 }
 
-article .wrapper:focus-visible {
+article .wrapper .webchat-media-template-image {
+	border-top-left-radius: var(--cc-bubble-border-radius);
+	border-top-right-radius: var(--cc-bubble-border-radius);
+}
+
+article .wrapper .webchat-media-template-image:focus-visible {
 	outline: 2px solid var(--cc-primary-color);
-	outline-offset: -3px;
 }
 
 article .wrapper img {

--- a/src/messages/Image/Image.module.css
+++ b/src/messages/Image/Image.module.css
@@ -6,12 +6,14 @@ article .wrapper {
 	outline: none;
 }
 
-article .wrapper .webchat-media-template-image {
+article .wrapper .fixedImage,
+article .wrapper .flexImage {
 	border-top-left-radius: var(--cc-bubble-border-radius);
 	border-top-right-radius: var(--cc-bubble-border-radius);
 }
 
-article .wrapper .webchat-media-template-image:focus-visible {
+article .wrapper .fixedImage:focus-visible,
+article .wrapper .flexImage:focus-visible {
 	outline: 2px solid var(--cc-primary-color);
 }
 

--- a/src/messages/Image/Image.tsx
+++ b/src/messages/Image/Image.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from "react";
+import { FC, useMemo, useRef, useState } from "react";
 import { ImageMessageContext } from "./context";
 import Lightbox from "./lightbox/Lightbox";
 import ImageThumb from "./ImageThumb";
@@ -14,6 +14,8 @@ const Image: FC = () => {
 
 	const button = buttons?.[0];
 
+	const buttonRef = useRef<HTMLDivElement>(null);
+
 	const isDownloadable =
 		(buttons as IWebchatButton[])?.find(
 			button => "type" in button && button.type === "web_url",
@@ -24,7 +26,10 @@ const Image: FC = () => {
 	const contextValue = useMemo(
 		() => ({
 			onExpand: () => isDownloadable && setShowLightbox(true),
-			onClose: () => setShowLightbox(false),
+			onClose: () => {
+				setShowLightbox(false);
+				buttonRef.current?.focus(); // Restore focus after closing the lightbox
+			},
 			url,
 			altText,
 			isDownloadable,
@@ -37,7 +42,7 @@ const Image: FC = () => {
 
 	return (
 		<ImageMessageContext.Provider value={contextValue}>
-			<ImageThumb />
+			<ImageThumb ref={buttonRef} />
 			{showLightbox && <Lightbox />}
 		</ImageMessageContext.Provider>
 	);

--- a/src/messages/Image/ImageThumb.tsx
+++ b/src/messages/Image/ImageThumb.tsx
@@ -23,7 +23,7 @@ const ImageThumb = forwardRef((_props, ref) => {
 
 	const wrapperClasses = cx({
 		wrapper: true,
-		wrapperDownloadable : isDownloadable,
+		wrapperDownloadable: isDownloadable,
 	});
 
 	const imageClasses = cx({

--- a/src/messages/Image/ImageThumb.tsx
+++ b/src/messages/Image/ImageThumb.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { forwardRef, useState } from "react";
 import classes from "./Image.module.css";
 import classnames from "classnames/bind";
 import { useImageMessageContext } from "./hooks";
@@ -8,7 +8,7 @@ import { DownloadIcon } from "src/assets/svg";
 
 const cx = classnames.bind(classes);
 
-const ImageThumb: FC = () => {
+const ImageThumb = forwardRef((_props, ref) => {
 	const { config, action, onEmitAnalytics } = useMessageContext();
 	const { url, altText, isDownloadable, onExpand, button } = useImageMessageContext();
 	const [isImageBroken, setImageBroken] = useState(false);
@@ -30,6 +30,7 @@ const ImageThumb: FC = () => {
 	return (
 		<div className={cx(classes.wrapper, isDownloadable && classes.wrapperDownloadable)}>
 			<div
+				ref={ref as React.RefObject<HTMLDivElement>}
 				className={imageClasses}
 				onClick={() => onExpand()}
 				onKeyDown={handleKeyDown}
@@ -62,6 +63,6 @@ const ImageThumb: FC = () => {
 			)}
 		</div>
 	);
-};
+});
 
 export default ImageThumb;

--- a/src/messages/Image/ImageThumb.tsx
+++ b/src/messages/Image/ImageThumb.tsx
@@ -21,6 +21,11 @@ const ImageThumb = forwardRef((_props, ref) => {
 
 	const isDynamicRatio = !!config?.settings?.layout?.dynamicImageAspectRatio;
 
+	const wrapperClasses = cx({
+		wrapper: true,
+		wrapperDownloadable : isDownloadable,
+	});
+
 	const imageClasses = cx({
 		"webchat-media-template-image": true,
 		flexImage: !isDynamicRatio,
@@ -28,7 +33,7 @@ const ImageThumb = forwardRef((_props, ref) => {
 	});
 
 	return (
-		<div className={cx(classes.wrapper, isDownloadable && classes.wrapperDownloadable)}>
+		<div className={wrapperClasses}>
 			<div
 				ref={ref as React.RefObject<HTMLDivElement>}
 				className={imageClasses}

--- a/src/messages/Image/ImageThumb.tsx
+++ b/src/messages/Image/ImageThumb.tsx
@@ -14,38 +14,40 @@ const ImageThumb: FC = () => {
 	const [isImageBroken, setImageBroken] = useState(false);
 
 	const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-		event.key === "Enter" && onExpand && onExpand();
+		if (event.key === "Enter" || event.key === " ") {
+			if (onExpand) onExpand();
+		}
 	};
 
 	const isDynamicRatio = !!config?.settings?.layout?.dynamicImageAspectRatio;
 
 	const imageClasses = cx({
 		"webchat-media-template-image": true,
-		wrapper: true,
 		flexImage: !isDynamicRatio,
 		fixedImage: isDynamicRatio,
-		wrapperDownloadable: isDownloadable,
 	});
 
 	return (
-		<div
-			className={imageClasses}
-			onClick={() => onExpand()}
-			onKeyDown={handleKeyDown}
-			tabIndex={isDownloadable ? 0 : -1}
-			role={isDownloadable ? "button" : undefined}
-			aria-label={isDownloadable ? "View Image in fullsize" : undefined}
-			data-testid="image-message"
-		>
-			{isImageBroken ? (
-				<span className={classes.brokenImage} />
-			) : (
-				<img
-					src={url}
-					alt={altText || "Attachment Image"}
-					onError={() => setImageBroken(true)}
-				/>
-			)}
+		<div className={cx(classes.wrapper, isDownloadable && classes.wrapperDownloadable)}>
+			<div
+				className={imageClasses}
+				onClick={() => onExpand()}
+				onKeyDown={handleKeyDown}
+				tabIndex={isDownloadable ? 0 : -1}
+				role={isDownloadable ? "button" : undefined}
+				aria-label={isDownloadable ? "View Image in fullsize" : undefined}
+				data-testid="image-message"
+			>
+				{isImageBroken ? (
+					<span className={classes.brokenImage} />
+				) : (
+					<img
+						src={url}
+						alt={altText || "Attachment Image"}
+						onError={() => setImageBroken(true)}
+					/>
+				)}
+			</div>
 			{button && (
 				<PrimaryButton
 					isActionButton

--- a/src/messages/Image/lightbox/Lightbox.module.css
+++ b/src/messages/Image/lightbox/Lightbox.module.css
@@ -78,6 +78,10 @@
 	opacity: 0.85;
 }
 
+.icon:focus-visible {
+	border: 2px solid var(--cc-primary-color);
+}
+
 .icon svg {
 	fill: var(--cc-black-10);
 }

--- a/src/messages/Image/lightbox/LightboxHeader.tsx
+++ b/src/messages/Image/lightbox/LightboxHeader.tsx
@@ -1,4 +1,4 @@
-import { FC, KeyboardEvent, useRef } from "react";
+import { FC, KeyboardEvent, useEffect, useRef } from "react";
 import { useImageMessageContext } from "../hooks";
 import classes from "./Lightbox.module.css";
 import { CloseIcon, DownloadIcon } from "src/assets/svg";
@@ -7,6 +7,12 @@ const LightboxHeader: FC = () => {
 	const { url, altText, onClose } = useImageMessageContext();
 
 	const firstButton = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		setTimeout(() => {
+			firstButton.current?.focus();
+		}, 100);
+	}, []);
 
 	const handleDownload = () => {
 		window.open(url, "_blank");


### PR DESCRIPTION
This PR fixes keyboard a11y issues in downloadable images

- Check if the downloadable image still works as before with mouse clicks
- When tabbing, see if the downloadable image gets focus and triggering it should open the lightbox.
- The Download button in lightbox should be autofocused on open
- When closing the lightbox, the focus should be restored to the clickable image.
- Check also the keyboard functionality of the Download button