### PR TITLE
Feature/75378 fix nested list header items

### DIFF
--- a/src/common/ActionButtons/ActionButton.module.css
+++ b/src/common/ActionButtons/ActionButton.module.css
@@ -33,7 +33,8 @@ a.button:focus {
 	background: var(--cc-primary-color-hover);
 }
 button.button:focus-visible,
-a.button:focus-visible {
+a.button:focus-visible,
+a.button:global(.phone-number-anchor):focus-visible {
 	outline: 2px solid var(--cc-primary-color);
 	outline-offset: 2px;
 }

--- a/src/common/ActionButtons/ActionButton.module.css
+++ b/src/common/ActionButtons/ActionButton.module.css
@@ -14,7 +14,7 @@ a.button {
 	outline: none;
 }
 
-a.button:global(.phone-number-anchor) {
+a.button:global(.phone-number-or-url-anchor) {
 	background: var(--cc-primary-color);
 }
 
@@ -34,7 +34,7 @@ a.button:focus {
 }
 button.button:focus-visible,
 a.button:focus-visible,
-a.button:global(.phone-number-anchor):focus-visible {
+a.button:global(.phone-number-or-url-anchor):focus-visible {
 	outline: 2px solid var(--cc-primary-color);
 	outline-offset: 2px;
 }

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -123,15 +123,6 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		props.action?.(button.payload, null, { label: button.title });
 	};
 
-	const handleKeyDown = (event: React.KeyboardEvent) => {
-		if (isURLComponent && event.key === "Enter") {
-			onClick(event as any);
-		}
-		if (!isURLComponent && (event.key === "Enter" || event.key === " ")) {
-			onClick(event as any);
-		}
-	};
-
 	const renderIcon = () => {
 		if (customIcon) return customIcon;
 		if (isWebURL && showUrlIcon) return <LinkIcon />;
@@ -141,7 +132,6 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	return (
 		<Component
 			onClick={onClick}
-			onKeyDown={handleKeyDown}
 			className={classnames(
 				classes.button,
 				isWebURL && classes.url,

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -70,11 +70,15 @@ const ActionButton: FC<ActionButtonProps> = props => {
 
 	const PhoneNumberAnchor = (props: React.HTMLAttributes<HTMLAnchorElement>) =>
 		button.payload ? <a {...props} href={`tel:${button.payload}`} /> : null;
+	const Anchor = (props: React.HTMLAttributes<HTMLAnchorElement>) =>
+		isWebURL ? <a {...props} href={button.url} target={button.target} /> : null;
 	const Button = (props: React.HTMLAttributes<HTMLButtonElement>) => (
 		<button {...props} disabled={disabled} aria-disabled={disabled} />
 	);
 
-	const Component = isPhoneNumber ? PhoneNumberAnchor : Button;
+	const isURLComponent = isWebURL || isPhoneNumber;
+	const URLComponent = isPhoneNumber ? PhoneNumberAnchor : Anchor;
+	const Component = isURLComponent ? URLComponent : Button;
 
 	const onClick = (event: React.MouseEvent) => {
 		event.stopPropagation();
@@ -119,6 +123,15 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		props.action?.(button.payload, null, { label: button.title });
 	};
 
+	const handleKeyDown = (event: React.KeyboardEvent) => {
+		if (isURLComponent && event.key === "Enter") {
+			onClick(event as any);
+		}
+		if (!isURLComponent && (event.key === "Enter" || event.key === " ")) {
+			onClick(event as any);
+		}
+	};
+
 	const renderIcon = () => {
 		if (customIcon) return customIcon;
 		if (isWebURL && showUrlIcon) return <LinkIcon />;
@@ -128,6 +141,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	return (
 		<Component
 			onClick={onClick}
+			onKeyDown={handleKeyDown}
 			className={classnames(
 				classes.button,
 				isWebURL && classes.url,
@@ -135,10 +149,10 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				disabled && classes.disabled,
 				disabled && "disabled",
 				isPhoneNumber && "phone-number-anchor",
+				isWebURL && "phone-number-anchor",
 			)}
 			aria-label={getAriaLabel()}
 			aria-disabled={disabled}
-			role={isWebURL ? "link" : undefined}
 		>
 			<Typography
 				variant={size === "large" ? "title1-semibold" : "cta-semibold"}

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -148,8 +148,8 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				props.className,
 				disabled && classes.disabled,
 				disabled && "disabled",
-				isPhoneNumber && "phone-number-anchor",
-				isWebURL && "phone-number-anchor",
+				isPhoneNumber && "phone-number-or-url-anchor",
+				isWebURL && "phone-number-or-url-anchor",
 			)}
 			aria-label={getAriaLabel()}
 			aria-disabled={disabled}

--- a/src/common/Buttons/Buttons.module.css
+++ b/src/common/Buttons/Buttons.module.css
@@ -11,9 +11,9 @@ button.actionButton {
 
 /* Primary Button */
 button.primaryButton.actionButton,
-a.primaryButton.actionButton:global(.phone-number-anchor),
+a.primaryButton.actionButton:global(.phone-number-or-url-anchor),
 button.primaryButton.button,
-a.primaryButton.button:global(.phone-number-anchor) {
+a.primaryButton.button:global(.phone-number-or-url-anchor) {
 	width: 100%;
 	border-radius: 10px;
 	background-color: var(--cc-secondary-color);
@@ -55,9 +55,9 @@ button.primaryButton.button:disabled:focus {
 
 /* Secondary Button */
 button.secondaryButton.actionButton,
-a.secondaryButton.actionButton:global(.phone-number-anchor),
+a.secondaryButton.actionButton:global(.phone-number-or-url-anchor),
 button.secondaryButton.button,
-a.secondaryButton.button:global(.phone-number-anchor) {
+a.secondaryButton.button:global(.phone-number-or-url-anchor) {
 	width: 100%;
 	border-radius: 10px;
 	background-color: var(--cc-white);

--- a/src/messages/List/List.module.css
+++ b/src/messages/List/List.module.css
@@ -122,6 +122,11 @@ article .wrapper .listItemRoot {
 	padding-top: 12px;
 }
 
+.listHeaderButtonWrapper button:focus {
+	border: 2px solid var(--cc-white);
+	outline-offset: 0px !important;
+}
+
 .listItemButtonWrapper {
 	padding: 0px 16px 16px;
 }

--- a/src/messages/List/List.module.css
+++ b/src/messages/List/List.module.css
@@ -55,6 +55,10 @@ article .wrapper .listItemRoot {
 	color: var(--cc-white);
 }
 
+.headerContentWithButton {
+	padding-bottom: 72px; /* 12px headerContent bottom padding + 44px button height + 16px button bottom padding */
+}
+
 .itemTitle {
 	margin-top: 0px;
 	margin-bottom: 0px;
@@ -117,15 +121,20 @@ article .wrapper .listItemRoot {
 	flex-shrink: 0;
 }
 
-.listHeaderButtonWrapper,
-.listItemButtonWrapper {
-	z-index: 1;
-	padding: 0 16px 16px 16px;
+.listHeaderButtonWrapper {
+	position: absolute;
+	bottom: 16px;
+	right: 16px;
+	left: 16px;
 }
 
 .listHeaderButtonWrapper button:focus {
 	border: 2px solid var(--cc-secondary-contrast-color);
 	outline-offset: 0px !important;
+}
+
+.listItemButtonWrapper {
+	padding: 0 16px 16px 16px;
 }
 
 .mainButtonWrapper {

--- a/src/messages/List/List.module.css
+++ b/src/messages/List/List.module.css
@@ -1,12 +1,17 @@
 article .wrapper {
 	max-width: 295px;
 	border-radius: var(--cc-bubble-border-radius);
-	overflow: hidden;
 	border: 1px solid var(--cc-black-80);
 	background-color: var(--cc-white);
 }
 
+article .wrapper .listItemRoot {
+	border-top-right-radius: var(--cc-bubble-border-radius);
+	border-top-left-radius: var(--cc-bubble-border-radius);
+}
+
 .headerWrapper {
+	border-radius: inherit;
 	position: relative;
 }
 
@@ -16,7 +21,7 @@ article .wrapper {
 
 .headerWrapper:focus-visible {
 	outline: 2px solid var(--cc-primary-color);
-	outline-offset: -3px;
+	outline-offset: 2px;
 }
 
 .darkLayer {
@@ -28,6 +33,7 @@ article .wrapper {
 	right: 0;
 	bottom: 0;
 	background-color: hsla(0, 0%, 0%, 0.3);
+	border-radius: inherit;
 }
 
 .headerContent {
@@ -66,6 +72,7 @@ article .wrapper {
 	aspect-ratio: 16/9;
 	background-size: cover;
 	background-position: center center;
+	border-radius: inherit;
 }
 
 .listItemWrapper {

--- a/src/messages/List/List.module.css
+++ b/src/messages/List/List.module.css
@@ -10,38 +10,44 @@ article .wrapper .listItemRoot {
 	border-top-left-radius: var(--cc-bubble-border-radius);
 }
 
-.headerWrapper {
+.headerRoot {
+	aspect-ratio: 16/9;
+	background-size: cover;
+	background-position: center center;
+	position: relative;
+	display: flex;
+	flex-direction: column;
+}
+
+.headerRoot::before {
+	content: "";
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: hsla(0, 0%, 0%, 0.4); /* image overlay */
+	border-radius: inherit;
+}
+
+.headerRoot:focus {
+	opacity: 0.6;
+}
+
+.headerContentWrapper {
 	border-radius: inherit;
 	position: relative;
+	flex-grow: 1;
+	align-content: flex-end;
 }
 
-.headerWrapper:focus {
-	opacity: 0.85;
-}
-
-.headerWrapper:focus-visible {
+.headerContentWrapper:focus-visible {
 	outline: 2px solid var(--cc-primary-color);
-	outline-offset: 2px;
-}
-
-.darkLayer {
-	display: block;
-	content: " ";
-	position: absolute;
-	left: 0;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	background-color: hsla(0, 0%, 0%, 0.3);
-	border-radius: inherit;
+	box-shadow: inset 0 0 0 2px var(--cc-white);
 }
 
 .headerContent {
-	position: absolute;
-	left: 0;
-	bottom: 0;
-	right: 0;
-	padding: 16px;
+	padding: 16px 16px 12px 16px;
 	color: var(--cc-white);
 }
 
@@ -66,13 +72,6 @@ article .wrapper .listItemRoot {
 
 .itemSubtitle.ignoreWS {
 	white-space: initial;
-}
-
-.headerImage {
-	aspect-ratio: 16/9;
-	background-size: cover;
-	background-position: center center;
-	border-radius: inherit;
 }
 
 .listItemWrapper {
@@ -118,17 +117,15 @@ article .wrapper .listItemRoot {
 	flex-shrink: 0;
 }
 
-.listHeaderButtonWrapper {
-	padding-top: 12px;
+.listHeaderButtonWrapper,
+.listItemButtonWrapper {
+	z-index: 1;
+	padding: 0 16px 16px 16px;
 }
 
 .listHeaderButtonWrapper button:focus {
 	border: 2px solid var(--cc-secondary-contrast-color);
 	outline-offset: 0px !important;
-}
-
-.listItemButtonWrapper {
-	padding: 0px 16px 16px;
 }
 
 .mainButtonWrapper {

--- a/src/messages/List/List.module.css
+++ b/src/messages/List/List.module.css
@@ -123,7 +123,7 @@ article .wrapper .listItemRoot {
 }
 
 .listHeaderButtonWrapper button:focus {
-	border: 2px solid var(--cc-white);
+	border: 2px solid var(--cc-secondary-contrast-color);
 	outline-offset: 0px !important;
 }
 

--- a/src/messages/List/ListItem.tsx
+++ b/src/messages/List/ListItem.tsx
@@ -121,6 +121,7 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 							className={classnames(
 								"webchat-list-template-header-content",
 								classes.headerContent,
+								button && classes.headerContentWithButton,
 							)}
 						>
 							{renderTitles}

--- a/src/messages/List/ListItem.tsx
+++ b/src/messages/List/ListItem.tsx
@@ -94,7 +94,7 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 	}, [subtitleHtml, subtitleId, titleHtml, isHeaderElement]);
 
 	return (
-		<div role="listitem">
+		<div role="listitem" className={classes.listItemRoot}>
 			<div
 				className={rootClasses}
 				onClick={handleClick}

--- a/src/messages/List/ListItem.tsx
+++ b/src/messages/List/ListItem.tsx
@@ -42,22 +42,24 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 	const subtitleHtml = isSanitizeEnabled ? sanitizeHTML(subtitle) : subtitle;
 	const subtitleId = useRandomId("webchatListTemplateHeaderSubtitle");
 
-	const rootClasses = isHeaderElement
-		? classnames("webchat-list-template-header", classes.headerWrapper)
+	const rootClasses = classnames(classes.listItemRoot, isHeaderElement && classes.headerRoot);
+
+	const contentClasses = isHeaderElement
+		? classnames("webchat-list-template-header", classes.headerContentWrapper)
 		: classnames("webchat-list-template-element", classes.listItemWrapper);
 
 	const renderImage = useMemo(() => {
 		if (!image_url) return null;
 		return (
 			<div
-				className={isHeaderElement ? classes.headerImage : classes.listItemImage}
+				className={classes.listItemImage}
 				style={{ backgroundImage: getBackgroundImage(image_url) }}
-				data-testid={isHeaderElement ? "header-image" : "regular-image"}
+				data-testid="regular-image"
 			>
 				<span role="img" aria-label={image_alt_text || "Attachment Image"} />
 			</div>
 		);
-	}, [image_alt_text, image_url, isHeaderElement]);
+	}, [image_alt_text, image_url]);
 
 	const renderTitles = useMemo(() => {
 		if (!titleHtml && !subtitleHtml) return null;
@@ -94,9 +96,17 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 	}, [subtitleHtml, subtitleId, titleHtml, isHeaderElement]);
 
 	return (
-		<div role="listitem" className={classes.listItemRoot}>
+		<div
+			role="listitem"
+			className={rootClasses}
+			style={{
+				backgroundImage:
+					isHeaderElement && image_url ? getBackgroundImage(image_url) : undefined,
+			}}
+			data-testid={isHeaderElement ? "header-image" : "list-item"}
+		>
 			<div
-				className={rootClasses}
+				className={contentClasses}
 				onClick={handleClick}
 				onKeyDown={handleKeyDown}
 				role={default_action?.url ? "link" : undefined}
@@ -107,8 +117,6 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 			>
 				{isHeaderElement ? (
 					<>
-						{renderImage}
-						<div className={classes.darkLayer} />
 						<div
 							className={classnames(
 								"webchat-list-template-header-content",
@@ -116,15 +124,6 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 							)}
 						>
 							{renderTitles}
-							<PrimaryButton
-								isActionButton
-								action={shouldBeDisabled ? undefined : action}
-								button={button}
-								buttonClassName="webchat-list-template-header-button"
-								containerClassName={classes.listHeaderButtonWrapper}
-								config={config}
-								onEmitAnalytics={onEmitAnalytics}
-							/>
 						</div>
 					</>
 				) : (
@@ -139,7 +138,17 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 					</div>
 				)}
 			</div>
-			{!isHeaderElement && (
+			{isHeaderElement ? (
+				<PrimaryButton
+					isActionButton
+					action={shouldBeDisabled ? undefined : action}
+					button={button}
+					buttonClassName="webchat-list-template-header-button"
+					containerClassName={classes.listHeaderButtonWrapper}
+					config={config}
+					onEmitAnalytics={onEmitAnalytics}
+				/>
+			) : (
 				<SecondaryButton
 					isActionButton
 					action={shouldBeDisabled ? undefined : action}

--- a/src/messages/Message.module.css
+++ b/src/messages/Message.module.css
@@ -29,11 +29,11 @@
 	flex: 1;
 }
 
-.message a:not(:global(.phone-number-anchor)) {
+.message a:not(:global(.phone-number-or-url-anchor)) {
 	color: var(--cc-text-link);
 }
 
-.message a:hover:not(:global(.phone-number-anchor)),
-.message a:focus:not(:global(.phone-number-anchor)) {
+.message a:hover:not(:global(.phone-number-or-url-anchor)),
+.message a:focus:not(:global(.phone-number-or-url-anchor)) {
 	color: var(--cc-text-link-hover);
 }

--- a/test/fixtures/list.json
+++ b/test/fixtures/list.json
@@ -66,9 +66,9 @@
 									"image_url": "https://placewaifu.com/image/300/300",
 									"buttons": [
 										{
-											"payload": "foobar009l1b1",
-											"type": "postback",
-											"title": "foobar009l1b1"
+											"payload": "0123456789",
+											"type": "phone_number",
+											"title": "Call_foobar009l1b2"
 										}
 									],
 									"default_action": {


### PR DESCRIPTION
This PR fixes accessibility issues in list message

Success Criteria
- The header item in the list receives visible focus outline
- The button in the list header gets visible focus outline
- The focus border color of the header button is the contrasting color of the button background color
- The header button should not be nested inside the clickable header container div.
- When the button inside the clickable header is triggered, it should not bubble the click to the container div
- Action button of type 'web_url' should use 'a' tag instead of the 'button' tag with 'role=link'
- All type of action buttons should be keyboard accessible (If it is a link, then enter key press should trigger the link. If it is button, then space-bar or enter key should trigger it)
- Phone number button should receive visible focus border on keyboard focus
- The list should look and behave the same for mouse users.

How to test:
- Check the list item component in the demo page. 
- Also, test it with webchat by configuring various different lists (with/ without header, with/ without buttons, without image, long subtitles etc) to see if nothing is broken.