### PR TITLE
Fix number 0 to be displayed in chat as text message

### DIFF
--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -179,7 +179,7 @@ const defaultConfig: MatchConfig[] = [
 				return false;
 			}
 
-			return !!message?.text;
+			return message?.text !== null && message?.text !== undefined;
 		},
 		component: Text,
 		name: "Text",

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -14,7 +14,8 @@ interface TextProps {
 
 const Text: FC<TextProps> = props => {
 	const { message, config } = useMessageContext();
-	const content = props.content || message?.text || "";
+	const text = message?.text?.toString();
+	const content = props.content || text || "";
 
 	const enhancedURLsText = config?.settings?.widgetSettings?.disableRenderURLsAsLinks
 		? content

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -418,7 +418,7 @@ const screens: TScreen[] = [
 					source: "bot",
 					text: 0,
 				},
-			}
+			},
 		],
 	},
 	{

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -412,6 +412,13 @@ const screens: TScreen[] = [
 					text: 'Large Image: <img src="https://www.cognigy.com/hs-fs/hubfs/AI%20agent%20business.png?width=1153&height=1024&name=AI%20agent%20business.png" alt="Alt text">',
 				},
 			},
+			{
+				// Number 0 as a text should be rendered as a text message
+				message: {
+					source: "bot",
+					text: 0,
+				},
+			}
 		],
 	},
 	{


### PR DESCRIPTION
This PR fixes a bug where message bubble is not displayed when message.text is a number 0. 

- Run the UI and check the Text tab. Scroll to the bottom and you will see a text bubble displaying 0. (I have modified the demo to test this)
