### PR TITLE
Bug/86469 data only message visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.36.0",
+	"version": "0.36.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.36.0",
+			"version": "0.36.1",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.36.0",
+	"version": "0.36.1",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
 	"module": "./dist/chat-components.js",

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -179,7 +179,7 @@ const defaultConfig: MatchConfig[] = [
 				return false;
 			}
 
-			return message?.text !== null && message?.text !== undefined;
+			return message?.text !== null && message?.text !== undefined && message?.text !== "";
 		},
 		component: Text,
 		name: "Text",

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -419,6 +419,18 @@ const screens: TScreen[] = [
 					text: 0,
 				},
 			},
+			{
+				// Data-only message should not render anything
+				message: {
+					source: "bot",
+					text: "",
+					data: {
+						_test: {
+							aaa: "bbb",
+						},
+					},
+				},
+			},
 		],
 	},
 	{


### PR DESCRIPTION
This PR fixes a bug where messages containing no text, but the data would still be rendered in the chat.

You can test by checking the demo page. "Text" tab should contain a message with "0" text as the last message. 