### PR TITLE
Feature/88773 new webchat settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ and much more. We aim to use these components in various products such as:
 
 `npm run test:watch`
 
+### To test in local Webchat v3 build:
+1. In /chat-components run `npm ci && npm run build && npm pack`
+2. In /Webchat folder run npm i with the correct relative path and file name, e.g. `npm i ../chat-components/cognigy-chat-components-0.36.1.tgz`
+
 ## Release
 
 `npm version patch`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ and much more. We aim to use these components in various products such as:
 `npm run test:watch`
 
 ### To test in local Webchat v3 build:
+
 1. In /chat-components run `npm ci && npm run build && npm pack`
 2. In /Webchat folder run npm i with the correct relative path and file name, e.g. `npm i ../chat-components/cognigy-chat-components-0.36.1.tgz`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.37.0",
+	"version": "0.38.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.37.0",
+			"version": "0.38.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.37.0",
+	"version": "0.38.0",
 	"type": "module",
 	"exports": "./dist/chat-components.js",
 	"module": "./dist/chat-components.js",

--- a/src/common/ChatBubble.module.css
+++ b/src/common/ChatBubble.module.css
@@ -10,6 +10,11 @@
 	white-space: pre-wrap;
 }
 
+.bubble.disableBorder {
+	border: none;
+	background: none !important;
+}
+
 article:global(.bot) .bubble {
 	background: var(--cc-background-bot-message);
 	color: var(--cc-bot-message-contrast-color);

--- a/src/common/ChatBubble.tsx
+++ b/src/common/ChatBubble.tsx
@@ -35,9 +35,16 @@ const ChatBubble: FC<IChatBubbleProps> = props => {
 		disableBorder && classes.disableBorder,
 	);
 
-	const style = (isBotMessage || isEngagementMessage) && botOutputMaxWidthPercentage ? { maxWidth: `${botOutputMaxWidthPercentage}%` } : {};
+	const style =
+		(isBotMessage || isEngagementMessage) && botOutputMaxWidthPercentage
+			? { maxWidth: `${botOutputMaxWidthPercentage}%` }
+			: {};
 
-	return <div className={classNames} style={style}>{props.children}</div>;
+	return (
+		<div className={classNames} style={style}>
+			{props.children}
+		</div>
+	);
 };
 
 export default ChatBubble;

--- a/src/common/ChatBubble.tsx
+++ b/src/common/ChatBubble.tsx
@@ -12,7 +12,7 @@ const ChatBubble: FC<IChatBubbleProps> = props => {
 	const { message, config } = useMessageContext();
 	const directionMapping = config?.settings?.widgetSettings?.sourceDirectionMapping;
 	const disableBotOutputBorder = config?.settings?.layout?.disableBotOutputBorder;
-	const botOutputMaxWidth = config?.settings?.layout?.botOutputMaxWidth;
+	const botOutputMaxWidthPercentage = config?.settings?.layout?.botOutputMaxWidthPercentage;
 
 	const isUserMessage = message.source === "user";
 	const isBotMessage = message.source === "bot";
@@ -35,7 +35,7 @@ const ChatBubble: FC<IChatBubbleProps> = props => {
 		disableBorder && classes.disableBorder,
 	);
 
-	const style = (isBotMessage || isEngagementMessage) && botOutputMaxWidth ? { maxWidth: `${botOutputMaxWidth}%` } : {};
+	const style = (isBotMessage || isEngagementMessage) && botOutputMaxWidthPercentage ? { maxWidth: `${botOutputMaxWidthPercentage}%` } : {};
 
 	return <div className={classNames} style={style}>{props.children}</div>;
 };

--- a/src/common/ChatBubble.tsx
+++ b/src/common/ChatBubble.tsx
@@ -17,8 +17,9 @@ const ChatBubble: FC<IChatBubbleProps> = props => {
 	const isUserMessage = message.source === "user";
 	const isBotMessage = message.source === "bot";
 	const isAgentMessage = message.source === "agent";
+	const isEngagementMessage = message.source === "engagement";
 
-	const disableBorder = isBotMessage && disableBotOutputBorder;
+	const disableBorder = (isBotMessage || isEngagementMessage) && disableBotOutputBorder;
 
 	const userMessageDirection = directionMapping?.user || "outgoing";
 	const botMessageDirection = directionMapping?.bot || "incoming";
@@ -34,7 +35,7 @@ const ChatBubble: FC<IChatBubbleProps> = props => {
 		disableBorder && classes.disableBorder,
 	);
 
-	const style = isBotMessage && botOutputMaxWidth ? { maxWidth: `${botOutputMaxWidth}%` } : {};
+	const style = (isBotMessage || isEngagementMessage) && botOutputMaxWidth ? { maxWidth: `${botOutputMaxWidth}%` } : {};
 
 	return <div className={classNames} style={style}>{props.children}</div>;
 };

--- a/src/common/ChatBubble.tsx
+++ b/src/common/ChatBubble.tsx
@@ -11,10 +11,14 @@ interface IChatBubbleProps {
 const ChatBubble: FC<IChatBubbleProps> = props => {
 	const { message, config } = useMessageContext();
 	const directionMapping = config?.settings?.widgetSettings?.sourceDirectionMapping;
+	const disableBotOutputBorder = config?.settings?.layout?.disableBotOutputBorder;
+	const botOutputMaxWidth = config?.settings?.layout?.botOutputMaxWidth;
 
 	const isUserMessage = message.source === "user";
 	const isBotMessage = message.source === "bot";
 	const isAgentMessage = message.source === "agent";
+
+	const disableBorder = isBotMessage && disableBotOutputBorder;
 
 	const userMessageDirection = directionMapping?.user || "outgoing";
 	const botMessageDirection = directionMapping?.bot || "incoming";
@@ -27,9 +31,12 @@ const ChatBubble: FC<IChatBubbleProps> = props => {
 		isUserMessage && classes[userMessageDirection],
 		isBotMessage && classes[botMessageDirection],
 		isAgentMessage && classes[agentMessageDirection],
+		disableBorder && classes.disableBorder,
 	);
 
-	return <div className={classNames}>{props.children}</div>;
+	const style = isBotMessage && botOutputMaxWidth ? { maxWidth: `${botOutputMaxWidth}%` } : {};
+
+	return <div className={classNames} style={style}>{props.children}</div>;
 };
 
 export default ChatBubble;

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -28,7 +28,7 @@ export interface IWebchatSettings {
 		watermark: "default" | "custom" | "none";
 		watermarkText: string;
 		disableBotOutputBorder: boolean;
-		botOutputMaxWidth: number;
+		botOutputMaxWidthPercentage: number;
 		chatWindowWidth: number;
 	};
 	colors: {

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -27,6 +27,8 @@ export interface IWebchatSettings {
 		disableUrlButtonSanitization: boolean;
 		watermark: "default" | "custom" | "none";
 		watermarkText: string;
+		disableBotOutputBorder: boolean;
+		botOutputMaxWidth: number;
 	};
 	colors: {
 		primaryColor: string;

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -29,6 +29,7 @@ export interface IWebchatSettings {
 		watermarkText: string;
 		disableBotOutputBorder: boolean;
 		botOutputMaxWidth: number;
+		chatWindowWidth: number;
 	};
 	colors: {
 		primaryColor: string;
@@ -39,6 +40,8 @@ export interface IWebchatSettings {
 		textLinkColor: string;
 	};
 	behavior: {
+		enableAIAgentNotice: boolean;
+		AIAgentNoticeText: string;
 		enableTypingIndicator: boolean;
 		messageDelay: number;
 		inputPlaceholder: string;
@@ -205,13 +208,11 @@ export interface IWebchatSettings {
 		sourceDirectionMapping: {
 			agent: TSourceDirection;
 			bot: TSourceDirection;
-			engagement: TSourceDirection;
 			user: TSourceDirection;
 		};
 		sourceColorMapping: {
 			agent: TSourceColor;
 			bot: TSourceColor;
-			engagement: TSourceColor;
 			user: TSourceColor;
 		};
 	};

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -454,7 +454,22 @@ const screens: TScreen[] = [
 				config: {
 					settings: {
 						layout: {
-							botOutputMaxWidth: 95,
+							botOutputMaxWidthPercentage: 95,
+						},
+					},
+				}
+			},
+			{
+				message: {
+					source: "bot",
+					text: "This is a message with the bot output border disabled and max width set to 95%",
+				},
+
+				config: {
+					settings: {
+						layout: {
+							disableBotOutputBorder: true,
+							botOutputMaxWidthPercentage: 95,
 						},
 					},
 				}

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -443,7 +443,7 @@ const screens: TScreen[] = [
 							disableBotOutputBorder: true,
 						},
 					},
-				}
+				},
 			},
 			{
 				message: {
@@ -457,7 +457,7 @@ const screens: TScreen[] = [
 							botOutputMaxWidthPercentage: 95,
 						},
 					},
-				}
+				},
 			},
 			{
 				message: {
@@ -472,7 +472,7 @@ const screens: TScreen[] = [
 							botOutputMaxWidthPercentage: 95,
 						},
 					},
-				}
+				},
 			},
 		],
 	},

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -431,6 +431,34 @@ const screens: TScreen[] = [
 					},
 				},
 			},
+			{
+				message: {
+					source: "bot",
+					text: "This is a message with the bot output border disabled",
+				},
+
+				config: {
+					settings: {
+						layout: {
+							disableBotOutputBorder: true,
+						},
+					},
+				}
+			},
+			{
+				message: {
+					source: "bot",
+					text: "This is a message with the bot output max width set to 95%",
+				},
+
+				config: {
+					settings: {
+						layout: {
+							botOutputMaxWidth: 95,
+						},
+					},
+				}
+			},
 		],
 	},
 	{


### PR DESCRIPTION
[https://cognigy.visualstudio.com/Team%20X/_workitems/edit/88773](https://cognigy.visualstudio.com/Team%20X/_workitems/edit/88773)

added 3 new webchat3 setting options:

1. disableBotOutputBorder - bot outputs without border
2. botOutputMaxWidthPercentage - bot outputs size (relative to window) in percentage
3. chatWindowWidth - width of webchat window

1 + 2 are handled in the chat components, 3. in the Webchat repo

To test: `npm run dev` and check bottom of text messages tab in the demo page. 