### PR TITLE
fix: #65312 add unicode character support to the link matcher regex

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,7 +93,7 @@ export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
 	//
 	const urlMatcherRegex =
-		/(^|\s)(\b(https?):\/\/([-A-Z0-9+&@$#/%?=~_|!:,.;\p{L}]*[-A-Z0-9+&$@#/%=~_|\p{L}]))/giu
+		/(^|\s)(\b(https?):\/\/([-A-Z0-9+&@$#/%?=~_|!:,.;\p{L}]*[-A-Z0-9+&$@#/%=~_|\p{L}]))/giu;
 
 	if (typeof text !== "string") return text;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,7 +92,7 @@ export const getRandomId = (prefix = "") => {
 export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
 	const urlMatcherRegex =
-		/(^|\s)(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/\S*)?/gm;
+		/(^|\s)(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/\S*)?/gm;
 
 	if (typeof text !== "string") return text;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,9 +91,9 @@ export const getRandomId = (prefix = "") => {
  */
 export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
-	// 
+	//
 	const urlMatcherRegex =
-		/(^|\s)(\b(https?):\/\/([-a-zA-Z0-9+&@#\/%?=~_|!:,.;](\p{L}).+)([-.][a-z0-9](\p{L}).+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/[^\s]*)?(\?[^\s]*)?)/giu
+		/(^|\s)(\b(https?):\/\/([-a-zA-Z0-9+&@#\/%?=~_|!:,.;](\p{L}).+)([-.][a-z0-9](\p{L}).+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/[^\s]*)?(\?[^\s]*)?)/giu;
 
 	if (typeof text !== "string") return text;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,8 +91,9 @@ export const getRandomId = (prefix = "") => {
  */
 export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
+	// 
 	const urlMatcherRegex =
-		/(^|\s)(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/[^\s]*)?(\?[^\s]*)?/gm;
+		/(^|\s)(\b(https?):\/\/([-a-zA-Z0-9+&@#\/%?=~_|!:,.;](\p{L}).+)([-.][a-z0-9](\p{L}).+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/[^\s]*)?(\?[^\s]*)?)/giu
 
 	if (typeof text !== "string") return text;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,7 +91,8 @@ export const getRandomId = (prefix = "") => {
  */
 export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
-	const urlMatcherRegex = /(^|\s)(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/\S*)?/gm;
+	const urlMatcherRegex =
+		/(^|\s)(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/\S*)?/gm;
 
 	if (typeof text !== "string") return text;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,7 +93,7 @@ export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
 	//
 	const urlMatcherRegex =
-		/(^|\s)(\b(https?):\/\/([-a-zA-Z0-9+&@#\/%?=~_|!:,.;](\p{L}).+)([-.][a-z0-9](\p{L}).+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/[^\s]*)?(\?[^\s]*)?)/giu;
+		/(^|\s)(\b(https?):\/\/([-A-Z0-9+&@$#/%?=~_|!:,.;\p{L}]*[-A-Z0-9+&$@#/%=~_|\p{L}]))/giu
 
 	if (typeof text !== "string") return text;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,7 +92,7 @@ export const getRandomId = (prefix = "") => {
 export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
 	const urlMatcherRegex =
-		/(^|\s)(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/\S*)?/gm;
+		/(^|\s)(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/[^\s]*)?(\?[^\s]*)?/gm;
 
 	if (typeof text !== "string") return text;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,8 +91,7 @@ export const getRandomId = (prefix = "") => {
  */
 export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	// Enhanced regex to better capture URLs with parameters
-	const urlMatcherRegex =
-		/(^|\s)(\b(https?):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/gi;
+	const urlMatcherRegex = /(^|\s)(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/\S*)?/gm;
 
 	if (typeof text !== "string") return text;
 

--- a/test/Text.spec.tsx
+++ b/test/Text.spec.tsx
@@ -1,28 +1,28 @@
-import { render, screen } from '@testing-library/react';
-import { describe, test, expect } from 'vitest';
-import { Message } from 'src/index';
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import { Message } from "src/index";
 
-describe('Text Component', () => {
-    test('renders the correct text with special characters', () => {
-        const testString = 'https://de.wikipedia.org/wiki/Düsseldorf';
-        render(<Message message={{text:testString}}/>);
+describe("Text Component", () => {
+	test("renders the correct text with special characters", () => {
+		const testString = "https://de.wikipedia.org/wiki/Düsseldorf";
+		render(<Message message={{ text: testString }} />);
 
-        const textElement = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Düsseldorf/i);
-        expect(textElement).toBeInTheDocument();
-        
-        const testString2 = 'https://de.wikipedia.org/wiki/Überlingen';
-        render(<Message message={{text:testString2}}/>);
-        const textElement2 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Überlingen/i);
-        expect(textElement2).toBeInTheDocument();
+		const textElement = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Düsseldorf/i);
+		expect(textElement).toBeInTheDocument();
 
-        const testString3 = 'https://de.wikipedia.org/wiki/Äpfel';
-        render(<Message message={{text:testString3}}/>);
-        const textElement3 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Äpfel/i);
-        expect(textElement3).toBeInTheDocument();
+		const testString2 = "https://de.wikipedia.org/wiki/Überlingen";
+		render(<Message message={{ text: testString2 }} />);
+		const textElement2 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Überlingen/i);
+		expect(textElement2).toBeInTheDocument();
 
-        const testString4 = 'https://de.wikipedia.org/wiki/Österreich';
-        render(<Message message={{text:testString4}}/>);
-        const textElement4 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Österreich/i);
-        expect(textElement4).toBeInTheDocument();
-    });
+		const testString3 = "https://de.wikipedia.org/wiki/Äpfel";
+		render(<Message message={{ text: testString3 }} />);
+		const textElement3 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Äpfel/i);
+		expect(textElement3).toBeInTheDocument();
+
+		const testString4 = "https://de.wikipedia.org/wiki/Österreich";
+		render(<Message message={{ text: testString4 }} />);
+		const textElement4 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Österreich/i);
+		expect(textElement4).toBeInTheDocument();
+	});
 });

--- a/test/Text.spec.tsx
+++ b/test/Text.spec.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect } from 'vitest';
+import { Message } from 'src/index';
+
+describe('Text Component', () => {
+    test('renders the correct text with special characters', () => {
+        const testString = 'https://de.wikipedia.org/wiki/Düsseldorf';
+        render(<Message message={{text:testString}}/>);
+
+        const textElement = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Düsseldorf/i);
+        expect(textElement).toBeInTheDocument();
+        
+        const testString2 = 'https://de.wikipedia.org/wiki/Überlingen';
+        render(<Message message={{text:testString2}}/>);
+        const textElement2 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Überlingen/i);
+        expect(textElement2).toBeInTheDocument();
+
+        const testString3 = 'https://de.wikipedia.org/wiki/Äpfel';
+        render(<Message message={{text:testString3}}/>);
+        const textElement3 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Äpfel/i);
+        expect(textElement3).toBeInTheDocument();
+
+        const testString4 = 'https://de.wikipedia.org/wiki/Österreich';
+        render(<Message message={{text:testString4}}/>);
+        const textElement4 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Österreich/i);
+        expect(textElement4).toBeInTheDocument();
+    });
+});

--- a/test/Text.spec.tsx
+++ b/test/Text.spec.tsx
@@ -7,8 +7,8 @@ describe("Text Component", () => {
 		"https://de.wikipedia.org/wiki/Düsseldorf",
 		"https://de.wikipedia.org/wiki/Überlingen",
 		"https://de.wikipedia.org/wiki/Äpfel",
-		"https://de.wikipedia.org/wiki/Österreich"
-	])("renders %s with special characters in single tag", (testString) => {
+		"https://de.wikipedia.org/wiki/Österreich",
+	])("renders %s with special characters in single tag", testString => {
 		render(<Message message={{ text: testString }} />);
 		const textElement = screen.getByText(testString);
 		expect(textElement).toBeInTheDocument();
@@ -20,19 +20,19 @@ describe("Text Component", () => {
 		["https://example.com/search?q=Äpfel"],
 		["https://example.com/Düsseldorf?q=Österreich&lang=de"],
 		["https://example.com/auth?token=123e4567-e89b-12d3-a456-426614174000"],
-		["https://example.com?token=123e4567-e89b-12d3-a456-426614174000"]
-	])("renders %s with query parameters in single tag", (testString) => {
+		["https://example.com?token=123e4567-e89b-12d3-a456-426614174000"],
+	])("renders %s with query parameters in single tag", testString => {
 		render(<Message message={{ text: testString }} />);
 		const textElement = screen.getByText(testString);
 		expect(textElement).toBeInTheDocument();
 	});
 
-	test.each([
-		"https://example.com/path#section1",
-		"https://example.com/path#Düsseldorf"
-	])("renders %s with deeplinks in single tag", (testString) => {
-		render(<Message message={{ text: testString }} />);
-		const textElement = screen.getByText(testString);
-		expect(textElement).toBeInTheDocument();
-	});
+	test.each(["https://example.com/path#section1", "https://example.com/path#Düsseldorf"])(
+		"renders %s with deeplinks in single tag",
+		testString => {
+			render(<Message message={{ text: testString }} />);
+			const textElement = screen.getByText(testString);
+			expect(textElement).toBeInTheDocument();
+		},
+	);
 });

--- a/test/Text.spec.tsx
+++ b/test/Text.spec.tsx
@@ -3,26 +3,36 @@ import { describe, test, expect } from "vitest";
 import { Message } from "src/index";
 
 describe("Text Component", () => {
-	test("renders the correct text with special characters", () => {
-		const testString = "https://de.wikipedia.org/wiki/Düsseldorf";
+	test.each([
+		"https://de.wikipedia.org/wiki/Düsseldorf",
+		"https://de.wikipedia.org/wiki/Überlingen",
+		"https://de.wikipedia.org/wiki/Äpfel",
+		"https://de.wikipedia.org/wiki/Österreich"
+	])("renders %s with special characters in single tag", (testString) => {
 		render(<Message message={{ text: testString }} />);
-
-		const textElement = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Düsseldorf/i);
+		const textElement = screen.getByText(testString);
 		expect(textElement).toBeInTheDocument();
+	});
 
-		const testString2 = "https://de.wikipedia.org/wiki/Überlingen";
-		render(<Message message={{ text: testString2 }} />);
-		const textElement2 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Überlingen/i);
-		expect(textElement2).toBeInTheDocument();
+	test.each([
+		["https://example.com/search?q=Düsseldorf"],
+		["https://example.com/search?q=Überlingen"],
+		["https://example.com/search?q=Äpfel"],
+		["https://example.com/Düsseldorf?q=Österreich&lang=de"],
+		["https://example.com/auth?token=123e4567-e89b-12d3-a456-426614174000"],
+		["https://example.com?token=123e4567-e89b-12d3-a456-426614174000"]
+	])("renders %s with query parameters in single tag", (testString) => {
+		render(<Message message={{ text: testString }} />);
+		const textElement = screen.getByText(testString);
+		expect(textElement).toBeInTheDocument();
+	});
 
-		const testString3 = "https://de.wikipedia.org/wiki/Äpfel";
-		render(<Message message={{ text: testString3 }} />);
-		const textElement3 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Äpfel/i);
-		expect(textElement3).toBeInTheDocument();
-
-		const testString4 = "https://de.wikipedia.org/wiki/Österreich";
-		render(<Message message={{ text: testString4 }} />);
-		const textElement4 = screen.getByText(/https:\/\/de\.wikipedia\.org\/wiki\/Österreich/i);
-		expect(textElement4).toBeInTheDocument();
+	test.each([
+		"https://example.com/path#section1",
+		"https://example.com/path#Düsseldorf"
+	])("renders %s with deeplinks in single tag", (testString) => {
+		render(<Message message={{ text: testString }} />);
+		const textElement = screen.getByText(testString);
+		expect(textElement).toBeInTheDocument();
 	});
 });

--- a/test/Text.spec.tsx
+++ b/test/Text.spec.tsx
@@ -3,36 +3,55 @@ import { describe, test, expect } from "vitest";
 import { Message } from "src/index";
 
 describe("Text Component", () => {
-	test.each([
-		"https://de.wikipedia.org/wiki/Düsseldorf",
-		"https://de.wikipedia.org/wiki/Überlingen",
-		"https://de.wikipedia.org/wiki/Äpfel",
-		"https://de.wikipedia.org/wiki/Österreich",
-	])("renders %s with special characters in single tag", testString => {
-		render(<Message message={{ text: testString }} />);
-		const textElement = screen.getByText(testString);
-		expect(textElement).toBeInTheDocument();
-	});
-
-	test.each([
-		["https://example.com/search?q=Düsseldorf"],
-		["https://example.com/search?q=Überlingen"],
-		["https://example.com/search?q=Äpfel"],
-		["https://example.com/Düsseldorf?q=Österreich&lang=de"],
-		["https://example.com/auth?token=123e4567-e89b-12d3-a456-426614174000"],
-		["https://example.com?token=123e4567-e89b-12d3-a456-426614174000"],
-	])("renders %s with query parameters in single tag", testString => {
-		render(<Message message={{ text: testString }} />);
-		const textElement = screen.getByText(testString);
-		expect(textElement).toBeInTheDocument();
-	});
-
-	test.each(["https://example.com/path#section1", "https://example.com/path#Düsseldorf"])(
-		"renders %s with deeplinks in single tag",
-		testString => {
+	describe("Links", () => {
+		test.each([
+			"https://de.wikipedia.org/wiki/Düsseldorf",
+			"https://de.wikipedia.org/wiki/Überlingen",
+			"https://de.wikipedia.org/wiki/Äpfel",
+			"https://de.wikipedia.org/wiki/Österreich",
+		])("renders %s with special characters in single tag", testString => {
 			render(<Message message={{ text: testString }} />);
 			const textElement = screen.getByText(testString);
 			expect(textElement).toBeInTheDocument();
-		},
-	);
+		});
+
+		test.each([
+			["https://example.com/search?q=Düsseldorf"],
+			["https://example.com/search?q=Überlingen"],
+			["https://example.com/search?q=Äpfel"],
+			["https://example.com/Düsseldorf?q=Österreich&lang=de"],
+			["https://example.com/auth?token=123e4567-e89b-12d3-a456-426614174000"],
+			["https://example.com?token=123e4567-e89b-12d3-a456-426614174000"],
+		])("renders %s with query parameters in single tag", testString => {
+			render(<Message message={{ text: testString }} />);
+			const textElement = screen.getByText(testString);
+			expect(textElement).toBeInTheDocument();
+		});
+
+		test.each(["https://example.com/path#section1", "https://example.com/path#Düsseldorf"])(
+			"renders %s with deeplinks in single tag",
+			testString => {
+				render(<Message message={{ text: testString }} />);
+				const textElement = screen.getByText(testString);
+				expect(textElement).toBeInTheDocument();
+			},
+		);
+
+		test.each([
+			"https://www.muller.mü$ler.de/müller",
+			"https://-isers.de",
+			"http://-isers.de",
+			"https://müller.com",
+			"http://localhost:8000",
+			"https://user:password@example.com/müller",
+			"https://user:müller@example.com?token=1838-389484",
+			"https://www.muller.mü$ler.de/mü$ler",
+			"https://www.muller.mü@ler.de/mü$ler",
+			"https://www.Düsseldorf.gov.de?lang=Düsseldorf",
+		])("renders %s with combination of unicode characters in single tag", testString => {
+			render(<Message message={{ text: testString }} />);
+			const textElement = screen.getByText(testString);
+			expect(textElement).toBeInTheDocument();
+		});
+	});
 });

--- a/test/Text.spec.tsx
+++ b/test/Text.spec.tsx
@@ -4,6 +4,11 @@ import { Message } from "src/index";
 
 describe("Text Component", () => {
 	describe("Links", () => {
+		test("renders all the links in the single paragra of text by breaking them",async ()=>{
+			render(<Message message={{ text: "This is the text I used for testing: You can visit https://example.com for general information or explore http://www.example.com for detailed guides. For API documentation, check https://subdomain.example.com/path/to/page. Developers often use http://localhost:3000 or https://127.0.0.1 for local testing. Resources like ftp://example.com/resource/file.txt are helpful, and UK visitors can use https://example.co.uk. For specific queries, try https://example.com?query=param&other=value, or jump directly to sections like https://example.com/path?query=param#fragment. To access restricted content, log in with https://user:passw$ord@example.com. For German users, domains such as https://müller.de or https://frühstück.com are also valid, and international users might visit https://täst.com." }} />);
+			const linkElem = screen.getAllByRole("link");
+			expect(linkElem.length).toBe(12);
+		})
 		test.each([
 			"https://de.wikipedia.org/wiki/Düsseldorf",
 			"https://de.wikipedia.org/wiki/Überlingen",
@@ -20,7 +25,7 @@ describe("Text Component", () => {
 			["https://example.com/search?q=Überlingen"],
 			["https://example.com/search?q=Äpfel"],
 			["https://example.com/Düsseldorf?q=Österreich&lang=de"],
-			["https://example.com/auth?token=123e4567-e89b-12d3-a456-426614174000"],
+			["https://example.com/auth?token=123e45$7-e89b-12d3-a456-426614174000"],
 			["https://example.com?token=123e4567-e89b-12d3-a456-426614174000"],
 		])("renders %s with query parameters in single tag", testString => {
 			render(<Message message={{ text: testString }} />);
@@ -38,14 +43,14 @@ describe("Text Component", () => {
 		);
 
 		test.each([
-			"https://www.muller.mü$ler.de/müller",
+			"https://www.muller.müler.de/müller",
 			"https://-isers.de",
 			"http://-isers.de",
 			"https://müller.com",
 			"http://localhost:8000",
-			"https://user:password@example.com/müller",
+			"https://user:passw$ord@example.com/müller",
 			"https://user:müller@example.com?token=1838-389484",
-			"https://www.muller.mü$ler.de/mü$ler",
+			"https://www.muller.müler.de/mü$ler",
 			"https://www.muller.mü@ler.de/mü$ler",
 			"https://www.Düsseldorf.gov.de?lang=Düsseldorf",
 		])("renders %s with combination of unicode characters in single tag", testString => {

--- a/test/Text.spec.tsx
+++ b/test/Text.spec.tsx
@@ -4,11 +4,17 @@ import { Message } from "src/index";
 
 describe("Text Component", () => {
 	describe("Links", () => {
-		test("renders all the links in the single paragra of text by breaking them",async ()=>{
-			render(<Message message={{ text: "This is the text I used for testing: You can visit https://example.com for general information or explore http://www.example.com for detailed guides. For API documentation, check https://subdomain.example.com/path/to/page. Developers often use http://localhost:3000 or https://127.0.0.1 for local testing. Resources like ftp://example.com/resource/file.txt are helpful, and UK visitors can use https://example.co.uk. For specific queries, try https://example.com?query=param&other=value, or jump directly to sections like https://example.com/path?query=param#fragment. To access restricted content, log in with https://user:passw$ord@example.com. For German users, domains such as https://müller.de or https://frühstück.com are also valid, and international users might visit https://täst.com." }} />);
+		test("renders all the links in the single paragra of text by breaking them", async () => {
+			render(
+				<Message
+					message={{
+						text: "This is the text I used for testing: You can visit https://example.com for general information or explore http://www.example.com for detailed guides. For API documentation, check https://subdomain.example.com/path/to/page. Developers often use http://localhost:3000 or https://127.0.0.1 for local testing. Resources like ftp://example.com/resource/file.txt are helpful, and UK visitors can use https://example.co.uk. For specific queries, try https://example.com?query=param&other=value, or jump directly to sections like https://example.com/path?query=param#fragment. To access restricted content, log in with https://user:passw$ord@example.com. For German users, domains such as https://müller.de or https://frühstück.com are also valid, and international users might visit https://täst.com.",
+					}}
+				/>,
+			);
 			const linkElem = screen.getAllByRole("link");
 			expect(linkElem.length).toBe(12);
-		})
+		});
 		test.each([
 			"https://de.wikipedia.org/wiki/Düsseldorf",
 			"https://de.wikipedia.org/wiki/Überlingen",


### PR DESCRIPTION
The `url matcher` Regular expression was not fulfilling links with characters such as umlauts. 
This PR modifies the current regx with unicode character support by adding \p{L}
This PR also adds a test case to cover this use case 

https://cognigy.visualstudio.com/Boron/_workitems/edit/65312/