### PR TITLE
Feature/84849 accessibility fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.43.0",
+	"version": "0.44.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.43.0",
+			"version": "0.44.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.43.0",
+	"version": "0.44.0",
 	"type": "module",
 	"main": "./dist/chat-components.js",
 	"exports": {

--- a/src/common/Avatar.tsx
+++ b/src/common/Avatar.tsx
@@ -49,11 +49,11 @@ const Avatar: FC<AvatarProps> = props => {
 
 	return (
 		<img
-			alt={`${message?.source || "unknown source"} avatar`}
+			alt=""
 			className={classNames}
 			src={avatarUrl}
 			onError={() => setAvatarUrl(placeholderAvatar)}
-			data-testid="avatar"
+			data-testid={`${message?.source || "unknown source"}-avatar`}
 		/>
 	);
 };

--- a/src/common/MessageHeader.tsx
+++ b/src/common/MessageHeader.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import classes from "./MessageHeader.module.css";
 import classnames from "classnames";
+import mainClasses from "src/main.module.css";
 import { useMessageContext } from "src/messages/hooks";
 import Avatar from "./Avatar";
 import { HeaderEllipsis } from "src/assets/svg";
@@ -52,10 +53,24 @@ const MessageHeader: FC<MessageHeaderProps> = props => {
 		name = overrides.botAvatarOverrideNameOnce;
 	}
 
+	const timestamp = new Date(recievedAt).toLocaleTimeString([], {
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+
 	return (
 		<header className={className} data-testid="message-header">
 			{props.enableAvatar && <Avatar />}
-			<Typography variant="title2-regular" component="div" className={classes.headerMeta}>
+			<span className={mainClasses.srOnly}>
+				{`At ${timestamp}, `}
+				{isUserMessage ? "You said:" : `${name} said:`}
+			</span>
+			<Typography
+				variant="title2-regular"
+				component="div"
+				className={classes.headerMeta}
+				aria-hidden="true"
+			>
 				{!isUserMessage && (
 					<>
 						<span data-testid="sender-name" className={classes["avatar-name"]}>
@@ -65,12 +80,7 @@ const MessageHeader: FC<MessageHeaderProps> = props => {
 					</>
 				)}
 				<span>
-					<time className={classes.timestamp}>
-						{new Date(recievedAt).toLocaleTimeString([], {
-							hour: "2-digit",
-							minute: "2-digit",
-						})}
-					</time>
+					<time className={classes.timestamp}>{timestamp}</time>
 				</span>
 			</Typography>
 		</header>

--- a/src/common/MessageHeader.tsx
+++ b/src/common/MessageHeader.tsx
@@ -69,7 +69,7 @@ const MessageHeader: FC<MessageHeaderProps> = props => {
 				variant="title2-regular"
 				component="div"
 				className={classes.headerMeta}
-				aria-hidden="true"
+				aria-hidden={true}
 			>
 				{!isUserMessage && (
 					<>

--- a/src/common/Typography/Typography.tsx
+++ b/src/common/Typography/Typography.tsx
@@ -10,6 +10,7 @@ export interface TypographyProps extends CSSProperties {
 	component?: keyof JSX.IntrinsicElements;
 	dangerouslySetInnerHTML?: { __html: string | TrustedHTML } | undefined;
 	id?: string;
+	"aria-hidden"?: boolean;
 }
 
 type TagVariants =
@@ -57,6 +58,7 @@ const Typography: FC<TypographyProps> = props => {
 		color,
 		dangerouslySetInnerHTML,
 		id,
+		"aria-hidden": ariaHidden,
 		...restProps
 	} = props;
 	const Component = component ?? variantsMapping[variant];
@@ -68,6 +70,7 @@ const Typography: FC<TypographyProps> = props => {
 			style={{ color: typographyColor, ...style, ...restProps }}
 			dangerouslySetInnerHTML={dangerouslySetInnerHTML}
 			id={id}
+			aria-hidden={ariaHidden}
 		>
 			{children}
 		</Component>

--- a/src/messages/Gallery/Gallery.module.css
+++ b/src/messages/Gallery/Gallery.module.css
@@ -180,12 +180,13 @@ article :global(.swiper).wrapper :global(.swiper-pagination-bullet) {
 	opacity: 1;
 }
 article :global(.swiper).wrapper :global(.swiper-pagination-bullet):focus {
+	background-color: var(--cc-primary-color);
 	box-shadow: 0 0 0 4px var(--cc-primary-color-opacity-10);
 	outline: none;
 }
 article :global(.swiper).wrapper :global(.swiper-pagination-bullet):focus-visible {
-	background-color: var(--cc-primary-color);
-	outline: "none";
+	outline: 2px solid var(--cc-primary-color);
+	outline-offset: 2px;
 }
 article :global(.swiper).wrapper :global(button.swiper-pagination-bullet) {
 	border: none;
@@ -203,7 +204,7 @@ article :global(.swiper).wrapper :global(.swiper-pagination-bullet:only-child) {
 }
 article :global(.swiper).wrapper :global(.swiper-pagination-bullet-active) {
 	opacity: 1;
-	background: var(--cc-primary-color);
+	background-color: black;
 }
 article
 	:global(.swiper).wrapper

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -77,8 +77,8 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 					onKeyDown={handleKeyDown}
 					role={default_action?.url ? "link" : undefined}
 					id={contentId}
-					aria-describedby={subtitle ? subtitleId : undefined}
-					aria-labelledby={title ? titleId : undefined}
+					aria-describedby={default_action?.url && subtitle ? subtitleId : undefined}
+					aria-labelledby={default_action?.url && title ? titleId : undefined}
 					aria-label={default_action?.url ? `${titleHtml}. Opens in new tab` : undefined}
 				>
 					{subtitle && (
@@ -100,6 +100,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 							action={shouldBeDisabled ? undefined : action}
 							config={config}
 							onEmitAnalytics={onEmitAnalytics}
+							templateTextId={title ? titleId : undefined}
 						/>
 					)}
 				</div>

--- a/test/Avatar.spec.tsx
+++ b/test/Avatar.spec.tsx
@@ -51,7 +51,10 @@ describe("Avatars", () => {
 			render(<Message message={messageAvatarOverride} />);
 		});
 
-		expect(screen.getByTestId("agent-avatar")).toHaveAttribute("src", agentAvatarOverrideUrlOnce);
+		expect(screen.getByTestId("agent-avatar")).toHaveAttribute(
+			"src",
+			agentAvatarOverrideUrlOnce,
+		);
 	});
 
 	it("shows the sender name from the override mechanism", async () => {

--- a/test/Avatar.spec.tsx
+++ b/test/Avatar.spec.tsx
@@ -35,7 +35,7 @@ describe("Avatars", () => {
 			render(<Message message={messageDefault} />);
 		});
 
-		expect(screen.getByTestId("avatar")).toHaveAttribute("src", defaultAgentAvatarUrl);
+		expect(screen.getByTestId("agent-avatar")).toHaveAttribute("src", defaultAgentAvatarUrl);
 	});
 
 	it("shows the avatar from the avatarUrl prop", async () => {
@@ -43,7 +43,7 @@ describe("Avatars", () => {
 			render(<Message message={messageAvatarUrl} />);
 		});
 
-		expect(screen.getByTestId("avatar")).toHaveAttribute("src", customAvatarUrl);
+		expect(screen.getByTestId("agent-avatar")).toHaveAttribute("src", customAvatarUrl);
 	});
 
 	it("shows the avatar from the override mechanism", async () => {
@@ -51,7 +51,7 @@ describe("Avatars", () => {
 			render(<Message message={messageAvatarOverride} />);
 		});
 
-		expect(screen.getByTestId("avatar")).toHaveAttribute("src", agentAvatarOverrideUrlOnce);
+		expect(screen.getByTestId("agent-avatar")).toHaveAttribute("src", agentAvatarOverrideUrlOnce);
 	});
 
 	it("shows the sender name from the override mechanism", async () => {


### PR DESCRIPTION
This PR fixes the below accessibility issues:
- Remove alt tag for message avatar
- Improve carousal dot keyboard focus style
- Add missing aria-labelledby to gallery button group
- The timestamp and message sender details are clearly available for screen-readers

Test the above success criteria locally with the demo. 