### PR TITLE
#76031: Improve button focus outlines

### DIFF
--- a/src/common/ActionButtons/ActionButton.module.css
+++ b/src/common/ActionButtons/ActionButton.module.css
@@ -38,6 +38,7 @@ a.button:focus-visible,
 a.button:global(.phone-number-or-url-anchor):focus-visible {
 	outline: 2px solid var(--cc-primary-color);
 	outline-offset: 2px;
+	box-shadow: 0 0 0 4px var(--cc-primary-contrast-color);
 }
 
 button.button:disabled,

--- a/src/common/ActionButtons/ActionButton.module.css
+++ b/src/common/ActionButtons/ActionButton.module.css
@@ -33,9 +33,11 @@ button.button:focus,
 a.button:focus {
 	background: var(--cc-primary-color-hover);
 }
-button.button:focus-visible,
-a.button:focus-visible,
-a.button:global(.phone-number-or-url-anchor):focus-visible {
+
+/* Explicitly increase the specificity of the :focus-visible selector by including the parent [data-cognigy-webchat-root] selector. This ensures custom focus styles override Firefox's default dotted outline. */
+[data-cognigy-webchat-root] button.button:focus-visible,
+[data-cognigy-webchat-root] a.button:focus-visible,
+[data-cognigy-webchat-root] a.button:global(.phone-number-or-url-anchor):focus-visible {
 	outline: 2px solid var(--cc-primary-color);
 	outline-offset: 2px;
 	box-shadow: 0 0 0 4px var(--cc-primary-contrast-color);

--- a/src/messages/List/List.module.css
+++ b/src/messages/List/List.module.css
@@ -128,11 +128,6 @@ article .wrapper .listItemRoot {
 	left: 16px;
 }
 
-.listHeaderButtonWrapper button:focus {
-	border: 2px solid var(--cc-secondary-contrast-color);
-	outline-offset: 0px !important;
-}
-
 .listItemButtonWrapper {
 	padding: 0 16px 16px 16px;
 }


### PR DESCRIPTION
This PR fixes the focus style of action buttons in webchat for keyboard focus.

**Success Criteria:**
 - You should now see 2 outlines for action buttons: 1 in primary color and the other in primary-contrast-color. (Compare the focus styles with dev)
 - Focus outlines of action buttons should also be clear in firefox

**How to test:**
- Open demo and navigate quick reply buttons, list and gallery items using Tab key and check the SC. 
- The above SC should also be true for URL or phone number buttons in list item header. (Cannot be tested in demo. Please pack chat-components and test in in webchat. For this you need to have a Say node of type list. Make the first list item as a header and add a button of type URL or phone number. Check the bug ticket #76031 for more details)
- The above SC should also be true for conversation starter buttons in home screen (Cannot be tested in demo. Please pack chat-components and test in in webchat.)
- Test the focus style in firefox too
