### PR TITLE
#73996 date picker a11y improvements

### DIFF
--- a/src/messages/DatePicker/DatePicker.module.css
+++ b/src/messages/DatePicker/DatePicker.module.css
@@ -122,7 +122,7 @@
 	outline: 0;
 }
 
-.wrapper .content :global(.flatpickr-calendar:focus-visible .flatpickr-innerContainer) {
+.wrapper .content :global(.flatpickr-calendar .flatpickr-innerContainer:focus-visible) {
 	outline: 2px solid var(--cc-primary-color);
 	outline-offset: 2px;
 }

--- a/src/messages/DatePicker/DatePicker.module.css
+++ b/src/messages/DatePicker/DatePicker.module.css
@@ -35,9 +35,9 @@
 .header .right {
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
-	width: 20px;
-	height: 20px;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
 	cursor: pointer;
 	border: none;
 	outline: none;
@@ -45,6 +45,12 @@
 	padding: 0;
 	background-color: transparent;
 	box-sizing: border-box;
+	border-radius: 4px;
+}
+
+.header .right:focus {
+	outline: 2px solid var(--cc-primary-color);
+	outline-offset: 2px;
 }
 
 .content {
@@ -150,6 +156,17 @@
 	cursor: pointer;
 	display: inline-flex;
 	z-index: 3;
+	width: 24px;
+	height: 24px;
+	justify-content: center;
+	align-items: center;
+	border-radius: 4px;
+}
+
+.wrapper .content :global(.flatpickr-months .flatpickr-prev-month):focus-visible,
+.wrapper .content :global(.flatpickr-months .flatpickr-next-month):focus-visible {
+	outline: 2px solid var(--cc-primary-color);
+	outline-offset: 2px;
 }
 
 .wrapper .content :global(.flatpickr-months .flatpickr-prev-month.flatpickr-disabled),
@@ -241,8 +258,7 @@
 	border-color: var(--cc-black-60);
 }
 .wrapper .content :global(.flatpickr-current-month .flatpickr-monthDropdown-months:focus) {
-	border-color: var(--cc-black-60);
-	outline: none;
+	outline: 2px solid var(--cc-primary-color);
 }
 .wrapper .content :global(.flatpickr-current-month .flatpickr-monthDropdown-months option) {
 	font-weight: normal;
@@ -279,7 +295,7 @@
 }
 
 .wrapper .content :global(.flatpickr-current-month input.cur-year:focus) {
-	outline: 0;
+	outline: 2px solid var(--cc-primary-color);
 }
 
 .wrapper .content :global(.flatpickr-current-month input.cur-year[disabled]),

--- a/src/messages/DatePicker/DatePicker.tsx
+++ b/src/messages/DatePicker/DatePicker.tsx
@@ -137,11 +137,15 @@ const DatePicker: FC = () => {
 				disabled={shouldBeDisabled}
 				data-testid="button-open"
 				ref={openButtonRef}
+				aria-expanded={showPicker}
+				aria-controls={`webchat-plugin-date-picker-${message.id}`}
+				aria-haspopup="dialog"
 			>
 				{openText}
 			</PrimaryButton>
 			{showPicker && (
 				<div
+					id={`webchat-plugin-date-picker-${message.id}`}
 					className={classnames(classes.wrapper, "webchat-plugin-date-picker")}
 					onKeyDown={handleKeyDown}
 					tabIndex={0}
@@ -171,6 +175,7 @@ const DatePicker: FC = () => {
 							aria-label={closeDatePickerLabel}
 							className={classes.right}
 							data-testid="button-close"
+							autoFocus
 						>
 							<CloseIcon />
 						</button>

--- a/src/messages/DatePicker/DatePicker.tsx
+++ b/src/messages/DatePicker/DatePicker.tsx
@@ -106,7 +106,7 @@ const DatePicker: FC = () => {
 				calender?.focus(); // Move focus to calender from submit button
 			} else if (isLastTimeInputFieldFocused) {
 				event.preventDefault();
-				button?.focus(); // Move focus to cancel button from last time input field
+				button?.focus(); // Move focus to submit button from last time input field
 			}
 		}
 		// Handle Reverse Tab Navigation

--- a/src/messages/DatePicker/DatePicker.tsx
+++ b/src/messages/DatePicker/DatePicker.tsx
@@ -8,11 +8,14 @@ import { getFocusableElements } from "src/utils";
 import { CloseIcon } from "src/assets/svg";
 import Typography from "src/common/Typography";
 import { PrimaryButton } from "src/common/Buttons";
-import mainClasses from "src/main.module.css";
 
 const DatePicker: FC = () => {
 	const { action, message, messageParams, config } = useMessageContext();
-	const options = useMemo(() => getOptionsFromMessage(message), [message]);
+
+	const options = useMemo(
+		() => getOptionsFromMessage(message, config?.settings?.customTranslations),
+		[message, config?.settings?.customTranslations],
+	);
 
 	const [showPicker, setShowPicker] = useState(false);
 	const [currentDate, setCurrentDate] = useState("");
@@ -20,7 +23,6 @@ const DatePicker: FC = () => {
 	const openButtonRef = useRef<HTMLButtonElement>(null);
 
 	const datePickerHeading = useRandomId("webchatDatePickerHeading");
-	const datePickerDescription = useRandomId("webchatDatePickerContentDescription");
 
 	if (!message?.data?._plugin || message.data._plugin.type !== "date-picker") return;
 
@@ -102,13 +104,6 @@ const DatePicker: FC = () => {
 
 	const closeDatePickerLabel =
 		config?.settings?.customTranslations?.ariaLabels?.closeDatePicker || "Close date-picker";
-	const datePickerDescriptionForSr =
-		config?.settings?.customTranslations?.ariaLabels?.datePickerDescription ||
-		`Please use Left/ Right arrows to move focus to previous/ next day.
-		 Please use Up/ Down arrows to move focus to the same day of previous/
-		 next week. Please use Control + Left/ Right arrows to change the grid of
-		 dates to previous/ next month. Please use Control + Up/ Down arrows to
-		 change the grid of dates to previous/ next year.`;
 
 	return (
 		<div data-testid="datepicker-message">
@@ -132,19 +127,15 @@ const DatePicker: FC = () => {
 					role="dialog"
 					aria-modal="true"
 					aria-labelledby={datePickerHeading}
-					aria-describedby={datePickerDescription}
 				>
 					<div
 						className={classnames(classes.header, "webchat-plugin-date-picker-header")}
 					>
-						<span className={mainClasses.srOnly} id={datePickerDescription}>
-							{datePickerDescriptionForSr}
-						</span>
 						<span className={classes.left}></span>
 						<span className={classes.center}>
 							<Typography
 								variant="h2-semibold"
-								component="span"
+								component="h3"
 								className="webchat-list-template-header-title"
 							>
 								{eventName || "Calendar"}

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -80,26 +80,30 @@ function customElements(pluginConfig: Config): Plugin {
 				".flatpickr-next-month",
 			) as HTMLElement;
 			if (prevButton) {
-				prevButton.setAttribute("tabindex", "0");
 				prevButton.setAttribute("aria-label", "Previous month");
 				prevButton.setAttribute("role", "button");
-				prevButton.addEventListener("keydown", event => {
-					if (event.key === "Enter" || event.key === " ") {
-						event.preventDefault();
-						fp.changeMonth(-1); // Move to the previous month
-					}
-				});
+				if (!prevButton.classList.contains("flatpickr-disabled")) {
+					prevButton.setAttribute("tabindex", "0");
+					prevButton.addEventListener("keydown", event => {
+						if (event.key === "Enter" || event.key === " ") {
+							event.preventDefault();
+							fp.changeMonth(-1); // Move to the previous month
+						}
+					});
+				}
 			}
 			if (nextButton) {
-				nextButton.setAttribute("tabindex", "0");
 				nextButton.setAttribute("aria-label", "Next month");
 				nextButton.setAttribute("role", "button");
-				nextButton.addEventListener("keydown", event => {
-					if (event.key === "Enter" || event.key === " ") {
-						event.preventDefault();
-						fp.changeMonth(1); // Move to the next month
-					}
-				});
+				if (!nextButton.classList.contains("flatpickr-disabled")) {
+					nextButton.setAttribute("tabindex", "0");
+					nextButton.addEventListener("keydown", event => {
+						if (event.key === "Enter" || event.key === " ") {
+							event.preventDefault();
+							fp.changeMonth(1); // Move to the next month
+						}
+					});
+				}
 			}
 		}
 

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -3,6 +3,7 @@ import { Instance } from "flatpickr/dist/types/instance";
 
 export interface Config {
 	arrowIcon: string;
+	customTranslations?: { [key: string]: string | object };
 }
 
 /**
@@ -11,7 +12,7 @@ export interface Config {
  */
 function customElements(pluginConfig: Config): Plugin {
 	return function (fp: Instance) {
-		const { arrowIcon } = pluginConfig;
+		const { arrowIcon, customTranslations } = pluginConfig;
 
 		function buildTimeArrows() {
 			if (!fp?.config?.enableTime) return;
@@ -80,7 +81,8 @@ function customElements(pluginConfig: Config): Plugin {
 				".flatpickr-next-month",
 			) as HTMLElement;
 			if (prevButton) {
-				prevButton.setAttribute("aria-label", "Previous month");
+				const prevButtonAriaLabel = customTranslations?.datePickerPreviousMonth as string;
+				prevButton.setAttribute("aria-label", prevButtonAriaLabel || "Previous month");
 				prevButton.setAttribute("role", "button");
 				if (!prevButton.classList.contains("flatpickr-disabled")) {
 					prevButton.setAttribute("tabindex", "0");
@@ -93,7 +95,8 @@ function customElements(pluginConfig: Config): Plugin {
 				}
 			}
 			if (nextButton) {
-				nextButton.setAttribute("aria-label", "Next month");
+				const nextButtonAriaLabel = customTranslations?.datePickerNextMonth as string;
+				nextButton.setAttribute("aria-label", nextButtonAriaLabel || "Next month");
 				nextButton.setAttribute("role", "button");
 				if (!nextButton.classList.contains("flatpickr-disabled")) {
 					nextButton.setAttribute("tabindex", "0");
@@ -134,7 +137,8 @@ function customElements(pluginConfig: Config): Plugin {
 			const monthLabel = document.createElement("label");
 			monthLabel.setAttribute("for", "webchat-monthSelector-datepicker");
 
-			monthLabel.textContent = "Month";
+			monthLabel.textContent =
+				(customTranslations?.datePickerMonthLabel as string) || "Month";
 
 			monthYearDiv?.prepend(monthLabel);
 
@@ -156,7 +160,7 @@ function customElements(pluginConfig: Config): Plugin {
 
 			const yearLabel = document.createElement("label");
 			yearLabel.setAttribute("for", "yearSelector-datepicker");
-			yearLabel.textContent = "Year";
+			yearLabel.textContent = (customTranslations?.datePickerYearLabel as string) || "Year";
 
 			yearInputWrapper?.prepend(yearLabel);
 

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -1,9 +1,10 @@
 import { Plugin } from "flatpickr/dist/types/options";
 import { Instance } from "flatpickr/dist/types/instance";
+import { IWebchatSettings } from "src/messages/types";
 
 export interface Config {
 	arrowIcon: string;
-	customTranslations?: { [key: string]: string | object };
+	customTranslations?: IWebchatSettings["customTranslations"];
 }
 
 /**
@@ -81,7 +82,7 @@ function customElements(pluginConfig: Config): Plugin {
 				".flatpickr-next-month",
 			) as HTMLElement;
 			if (prevButton) {
-				const prevButtonAriaLabel = customTranslations?.datePickerPreviousMonth as string;
+				const prevButtonAriaLabel = customTranslations?.ariaLabels?.datePickerPreviousMonth;
 				prevButton.setAttribute("aria-label", prevButtonAriaLabel || "Previous month");
 				prevButton.setAttribute("role", "button");
 				if (!prevButton.classList.contains("flatpickr-disabled")) {
@@ -95,7 +96,7 @@ function customElements(pluginConfig: Config): Plugin {
 				}
 			}
 			if (nextButton) {
-				const nextButtonAriaLabel = customTranslations?.datePickerNextMonth as string;
+				const nextButtonAriaLabel = customTranslations?.ariaLabels?.datePickerNextMonth;
 				nextButton.setAttribute("aria-label", nextButtonAriaLabel || "Next month");
 				nextButton.setAttribute("role", "button");
 				if (!nextButton.classList.contains("flatpickr-disabled")) {
@@ -137,8 +138,7 @@ function customElements(pluginConfig: Config): Plugin {
 			const monthLabel = document.createElement("label");
 			monthLabel.setAttribute("for", "webchat-monthSelector-datepicker");
 
-			monthLabel.textContent =
-				(customTranslations?.datePickerMonthLabel as string) || "Month";
+			monthLabel.textContent = customTranslations?.datePickerMonthLabel || "Month";
 
 			monthYearDiv?.prepend(monthLabel);
 
@@ -160,7 +160,7 @@ function customElements(pluginConfig: Config): Plugin {
 
 			const yearLabel = document.createElement("label");
 			yearLabel.setAttribute("for", "yearSelector-datepicker");
-			yearLabel.textContent = (customTranslations?.datePickerYearLabel as string) || "Year";
+			yearLabel.textContent = customTranslations?.datePickerYearLabel || "Year";
 
 			yearInputWrapper?.prepend(yearLabel);
 

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -130,41 +130,59 @@ function customElements(pluginConfig: Config): Plugin {
 			const monthSelector = monthYearDiv?.getElementsByClassName(
 				"flatpickr-monthDropdown-months",
 			)?.[0] as HTMLElement;
-			monthSelector?.setAttribute("id", "webchat-monthSelector-datepicker");
-			monthSelector?.classList.add("webchat-monthSelector-datepicker");
-			// unset aria-label attribute from month input to avoid redundancy
-			monthSelector?.removeAttribute("aria-label");
 
-			const monthLabel = document.createElement("label");
-			monthLabel.setAttribute("for", "webchat-monthSelector-datepicker");
+			if (monthSelector) {
+				monthSelector.setAttribute("id", "webchat-monthSelector-datepicker");
+				monthSelector.classList.add("webchat-monthSelector-datepicker");
+				// Remove aria-label attribute from month input to avoid redundancy
+				monthSelector.removeAttribute("aria-label");
 
-			monthLabel.textContent = customTranslations?.datePickerMonthLabel || "Month";
+				// Check if a label already exists for the monthSelector
+				const existingLabel = monthYearDiv?.querySelector(
+					"label[for='webchat-monthSelector-datepicker']",
+				);
 
-			monthYearDiv?.prepend(monthLabel);
+				// If no label exists, create and prepend a new one
+				if (!existingLabel) {
+					const monthLabel = document.createElement("label");
+					monthLabel.setAttribute("for", "webchat-monthSelector-datepicker");
+					monthLabel.textContent = customTranslations?.datePickerMonthLabel || "Month";
+					monthYearDiv?.prepend(monthLabel);
+				}
 
-			monthSelector?.setAttribute("tabindex", "0");
+				monthSelector.setAttribute("tabindex", "0");
+			}
 		}
 
 		// Set necessary label and attributes to year input for accessibility
 		function setYearSelectAlly() {
 			const monthYearDiv =
 				fp?.calendarContainer?.getElementsByClassName("flatpickr-current-month")[0];
-
+		
 			const yearInput = monthYearDiv?.getElementsByClassName("cur-year")?.[0] as HTMLElement;
-
-			const yearInputWrapper = yearInput?.parentElement as HTMLElement;
-			yearInput?.setAttribute("id", "yearSelector-datepicker");
-			yearInput?.classList.add("yearSelector-datepicker");
-			// unset aria-label attribute from year input to avaoid redundancy
-			yearInput?.removeAttribute("aria-label");
-
-			const yearLabel = document.createElement("label");
-			yearLabel.setAttribute("for", "yearSelector-datepicker");
-			yearLabel.textContent = customTranslations?.datePickerYearLabel || "Year";
-
-			yearInputWrapper?.prepend(yearLabel);
-
-			yearInput?.setAttribute("tabindex", "0");
+		
+			if (yearInput) {
+				const yearInputWrapper = yearInput?.parentElement as HTMLElement;
+				yearInput.setAttribute("id", "yearSelector-datepicker");
+				yearInput.classList.add("yearSelector-datepicker");
+				// Remove aria-label attribute from year input to avoid redundancy
+				yearInput.removeAttribute("aria-label");
+		
+				// Check if a label already exists for the yearInput
+				const existingLabel = yearInputWrapper?.querySelector(
+					"label[for='yearSelector-datepicker']",
+				);
+		
+				// If no label exists, create and prepend a new one
+				if (!existingLabel) {
+					const yearLabel = document.createElement("label");
+					yearLabel.setAttribute("for", "yearSelector-datepicker");
+					yearLabel.textContent = customTranslations?.datePickerYearLabel || "Year";
+					yearInputWrapper?.prepend(yearLabel);
+				}
+		
+				yearInput.setAttribute("tabindex", "0");
+			}
 		}
 
 		// Set necessary attributes to time picker fields for accessibility

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -185,7 +185,7 @@ function customElements(pluginConfig: Config): Plugin {
 				monthSelector.setAttribute("tabindex", "0");
 
 				monthSelector.addEventListener("keydown", event => {
-					// If Enter, stop propagation to Flatpickr's internal handlers, so that the select menu to open
+					// If Enter, stop propagation to Flatpickr's internal handlers, so that the select menu can open
 					if (event.key === "Enter") {
 						event.stopPropagation();
 					}

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -71,9 +71,38 @@ function customElements(pluginConfig: Config): Plugin {
 			}
 		}
 
-		function setTimeAlly() {
-			fp?.calendarContainer?.focus();
+		function setNavButtonsAlly() {
+			const prevButton = fp?.calendarContainer?.querySelector(
+				".flatpickr-prev-month",
+			) as HTMLElement;
+			const nextButton = fp?.calendarContainer?.querySelector(
+				".flatpickr-next-month",
+			) as HTMLElement;
+			if (prevButton) {
+				prevButton.setAttribute("tabindex", "0");
+				prevButton.setAttribute("aria-label", "Previous month");
+				prevButton.setAttribute("role", "button");
+				prevButton.addEventListener("keydown", event => {
+					if (event.key === "Enter" || event.key === " ") {
+						event.preventDefault();
+						fp.changeMonth(-1); // Move to the previous month
+					}
+				});
+			}
+			if (nextButton) {
+				nextButton.setAttribute("tabindex", "0");
+				nextButton.setAttribute("aria-label", "Next month");
+				nextButton.setAttribute("role", "button");
+				nextButton.addEventListener("keydown", event => {
+					if (event.key === "Enter" || event.key === " ") {
+						event.preventDefault();
+						fp.changeMonth(1); // Move to the next month
+					}
+				});
+			}
+		}
 
+		function setTimeAlly() {
 			fp?.calendarContainer?.setAttribute("tabIndex", "0");
 			fp?.calendarContainer?.setAttribute("aria-labelledby", "webchatDatePickerHeaderLabel");
 
@@ -96,17 +125,19 @@ function customElements(pluginConfig: Config): Plugin {
 			const monthSelector = monthYearDiv?.getElementsByClassName(
 				"flatpickr-monthDropdown-months",
 			)?.[0] as HTMLElement;
-			monthSelector?.setAttribute("id", "monthSelector-datepicker");
-			monthSelector?.classList.add("monthSelector-datepicker");
-			// unset aria-label attribute from month input to avaoid redundancy
+			monthSelector?.setAttribute("id", "webchat-monthSelector-datepicker");
+			monthSelector?.classList.add("webchat-monthSelector-datepicker");
+			// unset aria-label attribute from month input to avoid redundancy
 			monthSelector?.removeAttribute("aria-label");
 
 			const monthLabel = document.createElement("label");
-			monthLabel.setAttribute("for", "monthSelector-datepicker");
+			monthLabel.setAttribute("for", "webchat-monthSelector-datepicker");
 
 			monthLabel.textContent = "Month";
 
 			monthYearDiv?.prepend(monthLabel);
+
+			monthSelector?.setAttribute("tabindex", "0");
 		}
 
 		function setYearSelectAlly() {
@@ -126,6 +157,8 @@ function customElements(pluginConfig: Config): Plugin {
 			yearLabel.textContent = "Year";
 
 			yearInputWrapper?.prepend(yearLabel);
+
+			yearInput?.setAttribute("tabindex", "0");
 		}
 
 		return {
@@ -135,6 +168,8 @@ function customElements(pluginConfig: Config): Plugin {
 				setTimeAlly,
 				setMonthSelectAlly,
 				setYearSelectAlly,
+				setNavButtonsAlly,
+
 				() => {
 					fp?.loadedPlugins?.push("customElements");
 				},
@@ -145,7 +180,11 @@ function customElements(pluginConfig: Config): Plugin {
 				},
 				handleWeekNumbers,
 			],
-			onValueUpdate: [upsertTimeArrows],
+			onValueUpdate: [
+				upsertTimeArrows,
+				setMonthSelectAlly,
+				setYearSelectAlly,
+			],
 		};
 	};
 }

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -158,21 +158,21 @@ function customElements(pluginConfig: Config): Plugin {
 		function setYearSelectAlly() {
 			const monthYearDiv =
 				fp?.calendarContainer?.getElementsByClassName("flatpickr-current-month")[0];
-		
+
 			const yearInput = monthYearDiv?.getElementsByClassName("cur-year")?.[0] as HTMLElement;
-		
+
 			if (yearInput) {
 				const yearInputWrapper = yearInput?.parentElement as HTMLElement;
 				yearInput.setAttribute("id", "yearSelector-datepicker");
 				yearInput.classList.add("yearSelector-datepicker");
 				// Remove aria-label attribute from year input to avoid redundancy
 				yearInput.removeAttribute("aria-label");
-		
+
 				// Check if a label already exists for the yearInput
 				const existingLabel = yearInputWrapper?.querySelector(
 					"label[for='yearSelector-datepicker']",
 				);
-		
+
 				// If no label exists, create and prepend a new one
 				if (!existingLabel) {
 					const yearLabel = document.createElement("label");
@@ -180,7 +180,7 @@ function customElements(pluginConfig: Config): Plugin {
 					yearLabel.textContent = customTranslations?.datePickerYearLabel || "Year";
 					yearInputWrapper?.prepend(yearLabel);
 				}
-		
+
 				yearInput.setAttribute("tabindex", "0");
 			}
 		}

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -71,6 +71,7 @@ function customElements(pluginConfig: Config): Plugin {
 			}
 		}
 
+		// Set necessary attributes to make Previous and Next month buttons accessible
 		function setNavButtonsAlly() {
 			const prevButton = fp?.calendarContainer?.querySelector(
 				".flatpickr-prev-month",
@@ -102,22 +103,18 @@ function customElements(pluginConfig: Config): Plugin {
 			}
 		}
 
-		function setTimeAlly() {
-			fp?.calendarContainer?.setAttribute("tabIndex", "0");
-			fp?.calendarContainer?.setAttribute("aria-labelledby", "webchatDatePickerHeaderLabel");
-
-			if (fp?.config?.enableTime) {
-				const hourField = fp?.timeContainer?.getElementsByClassName("flatpickr-hour")?.[0];
-				hourField?.setAttribute("tabIndex", "0");
-				const minutesField =
-					fp?.timeContainer?.getElementsByClassName("flatpickr-minute")?.[0];
-				minutesField?.setAttribute("tabIndex", "0");
-				const amPmField = fp?.timeContainer?.getElementsByClassName("flatpickr-am-pm")?.[0];
-				amPmField?.setAttribute("tabIndex", "0");
-				amPmField?.setAttribute("role", "button");
+		// Remove tabindex from calender container and set it to innerContainer
+		function setDateSelectAlly() {
+			fp?.calendarContainer?.setAttribute("tabindex", "-1");
+			const daysContainer = fp?.calendarContainer?.getElementsByClassName(
+				"flatpickr-innerContainer",
+			)[0];
+			if (daysContainer) {
+				daysContainer.setAttribute("tabindex", "0");
 			}
 		}
 
+		// Set necessary label and attributes to month select for accessibility
 		function setMonthSelectAlly() {
 			const monthYearDiv =
 				fp?.calendarContainer?.getElementsByClassName("flatpickr-current-month")[0];
@@ -140,6 +137,7 @@ function customElements(pluginConfig: Config): Plugin {
 			monthSelector?.setAttribute("tabindex", "0");
 		}
 
+		// Set necessary label and attributes to year input for accessibility
 		function setYearSelectAlly() {
 			const monthYearDiv =
 				fp?.calendarContainer?.getElementsByClassName("flatpickr-current-month")[0];
@@ -161,10 +159,27 @@ function customElements(pluginConfig: Config): Plugin {
 			yearInput?.setAttribute("tabindex", "0");
 		}
 
+		// Set necessary attributes to time picker fields for accessibility
+		function setTimeAlly() {
+			fp?.calendarContainer?.setAttribute("aria-labelledby", "webchatDatePickerHeaderLabel");
+
+			if (fp?.config?.enableTime) {
+				const hourField = fp?.timeContainer?.getElementsByClassName("flatpickr-hour")?.[0];
+				hourField?.setAttribute("tabIndex", "0");
+				const minutesField =
+					fp?.timeContainer?.getElementsByClassName("flatpickr-minute")?.[0];
+				minutesField?.setAttribute("tabIndex", "0");
+				const amPmField = fp?.timeContainer?.getElementsByClassName("flatpickr-am-pm")?.[0];
+				amPmField?.setAttribute("tabIndex", "0");
+				amPmField?.setAttribute("role", "button");
+			}
+		}
+
 		return {
 			onReady: [
 				upsertTimeArrows,
 				buildTimeArrows,
+				setDateSelectAlly,
 				setTimeAlly,
 				setMonthSelectAlly,
 				setYearSelectAlly,
@@ -182,8 +197,11 @@ function customElements(pluginConfig: Config): Plugin {
 			],
 			onValueUpdate: [
 				upsertTimeArrows,
+				setDateSelectAlly,
+				setTimeAlly,
 				setMonthSelectAlly,
 				setYearSelectAlly,
+				setNavButtonsAlly,
 			],
 		};
 	};

--- a/src/messages/DatePicker/helpers.ts
+++ b/src/messages/DatePicker/helpers.ts
@@ -3,12 +3,13 @@ import l10n from "flatpickr/dist/l10n";
 import { Options } from "flatpickr/dist/types/options";
 import { key as LocaleKey } from "flatpickr/dist/types/locale";
 import { IMessage } from "@cognigy/socket-client";
+import { IWebchatSettings } from "../types";
 import customElements from "./flatpickr-plugins/customElements";
 import arrowIcon from "src/assets/svg/arrow_back.svg?raw";
 
 export const getOptionsFromMessage = (
 	message: IMessage,
-	customTranslations?: { [key: string]: string | object },
+	customTranslations?: IWebchatSettings["customTranslations"],
 ) => {
 	if (!message?.data?._plugin || message.data._plugin.type !== "date-picker") return;
 

--- a/src/messages/DatePicker/helpers.ts
+++ b/src/messages/DatePicker/helpers.ts
@@ -155,3 +155,31 @@ export const getOptionsFromMessage = (message: IMessage) => {
 
 	return options;
 };
+
+/**
+ * Determines the first and last time picker fields in the time picker.
+ * @param webchatWindow The container element for the date picker.
+ * @param enableTime Whether time selection is enabled.
+ * @param time_24hr Whether 24-hour time format is enabled.
+ * @returns An object containing the first and last time picker fields.
+ */
+export const getTimePickerFields = (
+	webchatWindow: HTMLElement | null,
+	enableTime: boolean,
+	time_24hr: boolean,
+) => {
+	if (!enableTime || !webchatWindow) {
+		return { firstTimePickerField: null, lastTimePickerField: null };
+	}
+
+	const hourField = webchatWindow?.getElementsByClassName("flatpickr-hour")?.[0] as HTMLElement;
+	const minutesField = webchatWindow?.getElementsByClassName(
+		"flatpickr-minute",
+	)?.[0] as HTMLElement;
+	const amPmField = webchatWindow?.getElementsByClassName("flatpickr-am-pm")?.[0] as HTMLElement;
+
+	const firstTimePickerField = hourField;
+	const lastTimePickerField = time_24hr ? minutesField : amPmField;
+
+	return { firstTimePickerField, lastTimePickerField };
+};

--- a/src/messages/DatePicker/helpers.ts
+++ b/src/messages/DatePicker/helpers.ts
@@ -6,7 +6,10 @@ import { IMessage } from "@cognigy/socket-client";
 import customElements from "./flatpickr-plugins/customElements";
 import arrowIcon from "src/assets/svg/arrow_back.svg?raw";
 
-export const getOptionsFromMessage = (message: IMessage) => {
+export const getOptionsFromMessage = (
+	message: IMessage,
+	customTranslations?: { [key: string]: string | object },
+) => {
 	if (!message?.data?._plugin || message.data._plugin.type !== "date-picker") return;
 
 	const data = message.data._plugin.data;
@@ -106,7 +109,7 @@ export const getOptionsFromMessage = (message: IMessage) => {
 		formatDate: !data.dateFormat
 			? (date: Date) => moment(date).locale(momentLocaleId).format(dateFormatLocalString)
 			: undefined,
-		plugins: [customElements({ arrowIcon })],
+		plugins: [customElements({ arrowIcon, customTranslations: customTranslations || {} })],
 	};
 
 	const enable_disable =

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -119,6 +119,8 @@ export interface IWebchatSettings {
 		delete?: string;
 		delete_anyway?: string;
 		cancel?: string;
+		datePickerMonthLabel?: string;
+		datePickerYearLabel?: string;
 		ariaLabels?: {
 			scrollToBottom?: string;
 			closeDialog?: string;
@@ -156,7 +158,8 @@ export interface IWebchatSettings {
 			fullSizeImageViewerTitle?: string;
 			downloadFullsizeImage?: string;
 			closeFullsizeImageModal?: string;
-			datePickerDescription?: string;
+			datePickerPreviousMonth?: string;
+			datePickerNextMonth?: string;
 		};
 	};
 	teaserMessage: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,49 +170,6 @@ export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	return enhancedText;
 };
 
-// /**
-//  * Utility function to get focusable elements and optionally find the next or previous focusable element.
-//  * @param element The container element to search for focusable elements.
-//  * @param currentElement Optional. The current element to find the next or previous focusable element relative to it.
-//  * @returns An object containing the first, last, all focusable elements, and the next/previous focusable elements.
-//  */
-// export const getFocusableElements = (element: HTMLElement, currentElement?: HTMLElement) => {
-// 	// Get all interactive elements in the given element
-// 	const interactiveEls = element?.querySelectorAll(
-// 		'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])',
-// 	);
-// 	const interactiveElsArray = interactiveEls && Array.from(interactiveEls);
-
-// 	// Filter all the interactive elements that are not disabled or have aria-hidden 'true'
-// 	const focusable = interactiveElsArray?.filter(
-// 		el => !el.hasAttribute("disabled") && !el.getAttribute("aria-hidden"),
-// 	);
-
-// 	// Get the first and last focusable elements
-// 	const firstFocusable = focusable && (focusable[0] as HTMLElement);
-// 	const lastFocusable = focusable && (focusable[focusable.length - 1] as HTMLElement);
-
-// 	// Initialize next and previous focusable elements
-// 	let nextFocusable: HTMLElement | null = null;
-// 	let prevFocusable: HTMLElement | null = null;
-
-// 	// If a currentElement is provided, calculate next and previous focusable elements
-// 	if (currentElement && focusable) {
-// 		const currentIndex = focusable.indexOf(currentElement);
-
-// 		if (currentIndex !== -1) {
-// 			nextFocusable =
-// 				(focusable[currentIndex + 1] as HTMLElement) || (focusable[0] as HTMLElement);
-// 			prevFocusable =
-// 				(focusable[currentIndex - 1] as HTMLElement) ||
-// 				(focusable[focusable.length - 1] as HTMLElement);
-// 		}
-// 	}
-
-// 	// Return all focusable elements and their bounds
-// 	return { firstFocusable, lastFocusable, focusable, nextFocusable, prevFocusable };
-// };
-
 /**
  * Utility function to get focusable elements and find the next or previous focusable element relative to the currently focused element.
  * @param element The container element to search for focusable elements.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,3 +169,100 @@ export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 
 	return enhancedText;
 };
+
+// /**
+//  * Utility function to get focusable elements and optionally find the next or previous focusable element.
+//  * @param element The container element to search for focusable elements.
+//  * @param currentElement Optional. The current element to find the next or previous focusable element relative to it.
+//  * @returns An object containing the first, last, all focusable elements, and the next/previous focusable elements.
+//  */
+// export const getFocusableElements = (element: HTMLElement, currentElement?: HTMLElement) => {
+// 	// Get all interactive elements in the given element
+// 	const interactiveEls = element?.querySelectorAll(
+// 		'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])',
+// 	);
+// 	const interactiveElsArray = interactiveEls && Array.from(interactiveEls);
+
+// 	// Filter all the interactive elements that are not disabled or have aria-hidden 'true'
+// 	const focusable = interactiveElsArray?.filter(
+// 		el => !el.hasAttribute("disabled") && !el.getAttribute("aria-hidden"),
+// 	);
+
+// 	// Get the first and last focusable elements
+// 	const firstFocusable = focusable && (focusable[0] as HTMLElement);
+// 	const lastFocusable = focusable && (focusable[focusable.length - 1] as HTMLElement);
+
+// 	// Initialize next and previous focusable elements
+// 	let nextFocusable: HTMLElement | null = null;
+// 	let prevFocusable: HTMLElement | null = null;
+
+// 	// If a currentElement is provided, calculate next and previous focusable elements
+// 	if (currentElement && focusable) {
+// 		const currentIndex = focusable.indexOf(currentElement);
+
+// 		if (currentIndex !== -1) {
+// 			nextFocusable =
+// 				(focusable[currentIndex + 1] as HTMLElement) || (focusable[0] as HTMLElement);
+// 			prevFocusable =
+// 				(focusable[currentIndex - 1] as HTMLElement) ||
+// 				(focusable[focusable.length - 1] as HTMLElement);
+// 		}
+// 	}
+
+// 	// Return all focusable elements and their bounds
+// 	return { firstFocusable, lastFocusable, focusable, nextFocusable, prevFocusable };
+// };
+
+/**
+ * Utility function to get focusable elements and find the next or previous focusable element relative to the currently focused element.
+ * @param element The container element to search for focusable elements.
+ * @returns An object containing the first, last, all focusable elements, and the next/previous focusable elements.
+ */
+export const getFocusableElements = (element: HTMLElement) => {
+	// Get all interactive elements in the given element
+	const interactiveEls = element?.querySelectorAll(
+		'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])',
+	);
+	const interactiveElsArray = interactiveEls && Array.from(interactiveEls);
+
+	// Filter all the interactive elements that are not disabled or have aria-hidden 'true'
+	const focusable = interactiveElsArray?.filter(
+		el =>
+			!el.hasAttribute("disabled") &&
+			!el.getAttribute("aria-hidden") &&
+			!(el instanceof HTMLInputElement && el.readOnly) &&
+			!(el instanceof HTMLTextAreaElement && el.readOnly),
+	);
+
+	// Get the first and last focusable elements
+	const firstFocusable = focusable && (focusable[0] as HTMLElement);
+	const lastFocusable = focusable && (focusable[focusable.length - 1] as HTMLElement);
+
+	// Determine the currently focused element inside the container
+	const activeElement = document.activeElement as HTMLElement;
+	let currentElement: HTMLElement | null = null;
+
+	if (activeElement && element.contains(activeElement)) {
+		currentElement = activeElement;
+	}
+
+	// Initialize next and previous focusable elements
+	let nextFocusable: HTMLElement | null = null;
+	let prevFocusable: HTMLElement | null = null;
+
+	// If a currentElement is found, calculate next and previous focusable elements
+	if (currentElement && focusable) {
+		const currentIndex = focusable.indexOf(currentElement);
+
+		if (currentIndex !== -1) {
+			nextFocusable =
+				(focusable[currentIndex + 1] as HTMLElement) || (focusable[0] as HTMLElement); // Wrap around to the first element
+			prevFocusable =
+				(focusable[currentIndex - 1] as HTMLElement) ||
+				(focusable[focusable.length - 1] as HTMLElement); // Wrap around to the last element
+		}
+	}
+
+	// Return all focusable elements and their bounds
+	return { firstFocusable, lastFocusable, focusable, nextFocusable, prevFocusable };
+};


### PR DESCRIPTION
This PR improves the keyboard accessibility of the Date picker elements, specifically, the month, year, prev and next fields.
Success Criteria:
- Interactive elements in the datepicker receives visible focus indicators on keyboard navigation
- The order of elements getting focus is logical
- The focus is trapped inside the date-picker overlay
- Focus should automatically move to the close button in header when date-picker opens
- When the last element is focused, the focus should loop to the first element on Tab
- The Prev/ Next month buttons, Month select and year inputs should be accessible via keyboard. 
- Able to customize the Visible Month and Year labels and also the aria-labels of Prev/Next button
- Screen reader description for keyboard accessiblity is removed as it is not necessary anymore
- Date picker title has h3 tag instead of span

Out of Scope: Accessibility of 'day' picker

Work item numbers: 73996, 74763, 74764, 75645, 75647

How to test:
- Test the forward and reverse keyboard navigation in different date pickers in the demo
- Check the customization of labels and aria-labels
- In addition, build and pack chat-components and test it with webchat PR :https://github.com/Cognigy/Webchat/pull/105 and further customize the date and time pickers via the flow node
