### PR TITLE
Bug/95456 screen reader issues fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.49.0",
+	"version": "0.50.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.49.0",
+			"version": "0.50.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.49.0",
+	"version": "0.50.0",
 	"type": "module",
 	"main": "./dist/chat-components.js",
 	"exports": {

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -57,12 +57,12 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				? button.imageAltText
 				: "";
 
+	if (!buttonType) return null;
+
 	const buttonLabel = getWebchatButtonLabel(button) || "";
 	const __html = config?.settings?.layout?.disableHtmlContentSanitization
 		? buttonLabel
 		: sanitizeHTML(buttonLabel);
-
-	if (!buttonType) return null;
 
 	const isPhoneNumber =
 		button.payload && (buttonType === "phone_number" || buttonType === "user_phone_number");

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement, useEffect } from "react";
+import { FC, ReactElement } from "react";
 import classnames from "classnames";
 import { ActionButtonsProps } from "./ActionButtons";
 import { getWebchatButtonLabel } from "src/utils";
@@ -21,7 +21,6 @@ interface ActionButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
 	onEmitAnalytics: MessageProps["onEmitAnalytics"];
 	size?: "small" | "large";
 	openXAppOverlay?: (url: string | undefined) => void;
-	onRegisterLiveRegionButtons?: (label: string) => void;
 }
 
 /**
@@ -39,7 +38,6 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		onEmitAnalytics,
 		size,
 		openXAppOverlay,
-		onRegisterLiveRegionButtons,
 	} = props;
 	const buttonType =
 		"type" in button
@@ -63,11 +61,6 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	const __html = config?.settings?.layout?.disableHtmlContentSanitization
 		? buttonLabel
 		: sanitizeHTML(buttonLabel);
-
-	useEffect(() => {
-		if (!onRegisterLiveRegionButtons || !__html) return;
-		onRegisterLiveRegionButtons(__html);
-	}, [__html]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	if (!buttonType) return null;
 

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -79,13 +79,15 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	const isWebURLButtonTargetBlank = isWebURL && button.target !== "_self";
 	const opensInNewTabLabel =
 		config?.settings?.customTranslations?.ariaLabels?.opensInNewTab || "Opens in new tab";
+
 	const getAriaLabel = () => {
 		const isURLInNewTab = isWebURL && isWebURLButtonTargetBlank;
 		const newTabURLButtonTitle = `${buttonTitle}. ${opensInNewTabLabel}`;
 		const buttonTitleWithTarget = isURLInNewTab ? newTabURLButtonTitle : button.title;
 
+		//TODO: Test if adding the position and total is necessary in ariaLabels, by testing with NVDA. ORCA does not announce it with just default ol and li tags
 		if (total > 1) {
-			return `Item ${position} of ${total}: ${buttonTitleWithTarget}`;
+			return `${position} of ${total}: ${buttonTitleWithTarget}`;
 		} else if (total <= 1 && isURLInNewTab) {
 			return newTabURLButtonTitle;
 		}

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -21,7 +21,7 @@ interface ActionButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
 	onEmitAnalytics: MessageProps["onEmitAnalytics"];
 	size?: "small" | "large";
 	openXAppOverlay?: (url: string | undefined) => void;
-	onRegisterScreenReaderLabel?: (label: string) => void;
+	onRegisterLiveRegionButtons?: (label: string) => void;
 }
 
 /**
@@ -39,7 +39,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		onEmitAnalytics,
 		size,
 		openXAppOverlay,
-		onRegisterScreenReaderLabel,
+		onRegisterLiveRegionButtons,
 	} = props;
 	const buttonType =
 		"type" in button
@@ -65,8 +65,8 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		: sanitizeHTML(buttonLabel);
 
 	useEffect(() => {
-		if (!onRegisterScreenReaderLabel || !__html) return;
-		onRegisterScreenReaderLabel(__html);
+		if (!onRegisterLiveRegionButtons || !__html) return;
+		onRegisterLiveRegionButtons(__html);
 	}, [__html]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	if (!buttonType) return null;

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -21,7 +21,7 @@ interface ActionButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
 	onEmitAnalytics: MessageProps["onEmitAnalytics"];
 	size?: "small" | "large";
 	openXAppOverlay?: (url: string | undefined) => void;
-	onSetScreenReaderBtnLabel?: (label: string) => void;
+	onRegisterScreenReaderLabel?: (label: string) => void;
 }
 
 /**
@@ -39,7 +39,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		onEmitAnalytics,
 		size,
 		openXAppOverlay,
-		onSetScreenReaderBtnLabel,
+		onRegisterScreenReaderLabel,
 	} = props;
 	const buttonType =
 		"type" in button
@@ -65,10 +65,9 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		: sanitizeHTML(buttonLabel);
 
 	useEffect(() => {
-		if (!onSetScreenReaderBtnLabel) return;
-		if (!__html) return;
-		onSetScreenReaderBtnLabel(__html);
-	}, [__html, onSetScreenReaderBtnLabel]);
+		if (!onRegisterScreenReaderLabel || !__html) return;
+		onRegisterScreenReaderLabel(__html);
+	}, [__html]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	if (!buttonType) return null;
 

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement } from "react";
+import { FC, ReactElement, useEffect } from "react";
 import classnames from "classnames";
 import { ActionButtonsProps } from "./ActionButtons";
 import { getWebchatButtonLabel } from "src/utils";
@@ -21,6 +21,7 @@ interface ActionButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
 	onEmitAnalytics: MessageProps["onEmitAnalytics"];
 	size?: "small" | "large";
 	openXAppOverlay?: (url: string | undefined) => void;
+	onSetScreenReaderBtnLabel?: (label: string) => void;
 }
 
 /**
@@ -38,6 +39,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		onEmitAnalytics,
 		size,
 		openXAppOverlay,
+		onSetScreenReaderBtnLabel,
 	} = props;
 	const buttonType =
 		"type" in button
@@ -57,12 +59,18 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				? button.imageAltText
 				: "";
 
-	if (!buttonType) return null;
-
 	const buttonLabel = getWebchatButtonLabel(button) || "";
 	const __html = config?.settings?.layout?.disableHtmlContentSanitization
 		? buttonLabel
 		: sanitizeHTML(buttonLabel);
+
+	useEffect(() => {
+		if (!onSetScreenReaderBtnLabel) return;
+		if (!__html) return;
+		onSetScreenReaderBtnLabel(__html);
+	}, [__html, onSetScreenReaderBtnLabel]);
+
+	if (!buttonType) return null;
 
 	const isPhoneNumber =
 		button.payload && (buttonType === "phone_number" || buttonType === "user_phone_number");

--- a/src/common/ActionButtons/ActionButtons.module.css
+++ b/src/common/ActionButtons/ActionButtons.module.css
@@ -7,6 +7,8 @@
 	max-width: 295px;
 }
 
-ol, ul, li {
-    all: unset;
+ol,
+ul,
+li {
+	all: unset;
 }

--- a/src/common/ActionButtons/ActionButtons.module.css
+++ b/src/common/ActionButtons/ActionButtons.module.css
@@ -6,3 +6,7 @@
 	gap: 8px;
 	max-width: 295px;
 }
+
+ol, ul, li {
+    all: unset;
+}

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -100,7 +100,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 					className={classNames(mainClasses.srOnly, "sr-only")}
 					id={`srOnly-${templateTextId}`}
 				>
-					{`With ${buttons.length} buttons or links in`}
+					{`Contains ${buttons.length} buttons or links`}
 				</span>
 			)}
 			<div

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -25,7 +25,6 @@ export interface ActionButtonsProps {
 	size?: "small" | "large";
 	templateTextId?: string;
 	openXAppOverlay?: (url: string | undefined) => void;
-	onRegisterLiveRegionButtons?: (label: string) => void;
 }
 
 export const ActionButtons: FC<ActionButtonsProps> = props => {
@@ -43,7 +42,6 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 		onEmitAnalytics,
 		size,
 		templateTextId,
-		onRegisterLiveRegionButtons,
 	} = props;
 
 	const webchatButtonTemplateButtonId = useRandomId("webchatButtonTemplateButton");
@@ -92,7 +90,6 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 				size={size ? size : "small"}
 				id={`${webchatButtonTemplateButtonId}-${index}`}
 				openXAppOverlay={props.openXAppOverlay}
-				onRegisterLiveRegionButtons={onRegisterLiveRegionButtons}
 			/>
 		);
 

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -26,6 +26,7 @@ export interface ActionButtonsProps {
 	size?: "small" | "large";
 	templateTextId?: string;
 	openXAppOverlay?: (url: string | undefined) => void;
+	onSetScreenReaderBtnLabel?: (label: string) => void;
 }
 
 export const ActionButtons: FC<ActionButtonsProps> = props => {
@@ -42,6 +43,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 		onEmitAnalytics,
 		size,
 		templateTextId,
+		onSetScreenReaderBtnLabel,
 	} = props;
 
 	const webchatButtonTemplateButtonId = useRandomId("webchatButtonTemplateButton");
@@ -90,6 +92,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 			size={size ? size : "small"}
 			id={`${webchatButtonTemplateButtonId}-${index}`}
 			openXAppOverlay={props.openXAppOverlay}
+			onSetScreenReaderBtnLabel={onSetScreenReaderBtnLabel}
 		/>
 	));
 

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -25,7 +25,7 @@ export interface ActionButtonsProps {
 	size?: "small" | "large";
 	templateTextId?: string;
 	openXAppOverlay?: (url: string | undefined) => void;
-	onRegisterScreenReaderLabel?: (label: string) => void;
+	onRegisterLiveRegionButtons?: (label: string) => void;
 }
 
 export const ActionButtons: FC<ActionButtonsProps> = props => {
@@ -43,7 +43,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 		onEmitAnalytics,
 		size,
 		templateTextId,
-		onRegisterScreenReaderLabel,
+		onRegisterLiveRegionButtons,
 	} = props;
 
 	const webchatButtonTemplateButtonId = useRandomId("webchatButtonTemplateButton");
@@ -92,7 +92,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 				size={size ? size : "small"}
 				id={`${webchatButtonTemplateButtonId}-${index}`}
 				openXAppOverlay={props.openXAppOverlay}
-				onRegisterScreenReaderLabel={onRegisterScreenReaderLabel}
+				onRegisterLiveRegionButtons={onRegisterLiveRegionButtons}
 			/>
 		);
 

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -26,7 +26,7 @@ export interface ActionButtonsProps {
 	size?: "small" | "large";
 	templateTextId?: string;
 	openXAppOverlay?: (url: string | undefined) => void;
-	onSetScreenReaderBtnLabel?: (label: string) => void;
+	onRegisterScreenReaderLabel?: (label: string) => void;
 }
 
 export const ActionButtons: FC<ActionButtonsProps> = props => {
@@ -43,7 +43,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 		onEmitAnalytics,
 		size,
 		templateTextId,
-		onSetScreenReaderBtnLabel,
+		onRegisterScreenReaderLabel,
 	} = props;
 
 	const webchatButtonTemplateButtonId = useRandomId("webchatButtonTemplateButton");
@@ -92,7 +92,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 			size={size ? size : "small"}
 			id={`${webchatButtonTemplateButtonId}-${index}`}
 			openXAppOverlay={props.openXAppOverlay}
-			onSetScreenReaderBtnLabel={onSetScreenReaderBtnLabel}
+			onRegisterScreenReaderLabel={onRegisterScreenReaderLabel}
 		/>
 	));
 

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -1,11 +1,9 @@
 import { IWebchatButton, IWebchatQuickReply } from "@cognigy/socket-client";
 import { ActionButton } from ".";
 import classnames from "classnames";
-import mainClasses from "src/main.module.css";
 import classes from "./ActionButtons.module.css";
 import { FC, ReactElement, useEffect } from "react";
 import { MessageProps } from "src/messages/Message";
-import classNames from "classnames";
 import { useRandomId } from "src/messages/hooks";
 
 type buttonPayloadCompatibility = {
@@ -19,6 +17,7 @@ export interface ActionButtonsProps {
 	containerClassName?: string;
 	containerStyle?: React.CSSProperties;
 	buttonClassName?: string;
+	buttonListItemClassName?: string;
 	customIcon?: ReactElement;
 	showUrlIcon?: boolean;
 	config: MessageProps["config"];
@@ -34,6 +33,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 		className,
 		payload,
 		buttonClassName,
+		buttonListItemClassName,
 		containerClassName,
 		containerStyle,
 		action,
@@ -76,50 +76,51 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 		return true;
 	});
 
-	const buttonElements = buttons.map((button, index: number) => (
-		<ActionButton
-			className={buttonClassName}
-			key={index}
-			button={button}
-			action={action}
-			position={index + 1}
-			total={payload.length}
-			disabled={action === undefined}
-			customIcon={customIcon}
-			showUrlIcon={showUrlIcon}
-			config={config}
-			onEmitAnalytics={onEmitAnalytics}
-			size={size ? size : "small"}
-			id={`${webchatButtonTemplateButtonId}-${index}`}
-			openXAppOverlay={props.openXAppOverlay}
-			onRegisterScreenReaderLabel={onRegisterScreenReaderLabel}
-		/>
-	));
+	const buttonElements = buttons.map((button, index: number) => {
+		const actionButton = (
+			<ActionButton
+				className={buttonClassName}
+				button={button}
+				action={action}
+				disabled={action === undefined}
+				position={index + 1}
+				total={buttons.length}
+				customIcon={customIcon}
+				showUrlIcon={showUrlIcon}
+				config={config}
+				onEmitAnalytics={onEmitAnalytics}
+				size={size ? size : "small"}
+				id={`${webchatButtonTemplateButtonId}-${index}`}
+				openXAppOverlay={props.openXAppOverlay}
+				onRegisterScreenReaderLabel={onRegisterScreenReaderLabel}
+			/>
+		);
+
+		return buttons.length > 1 ? (
+			<li
+				key={index}
+				className={buttonListItemClassName}
+				aria-posinset={index + 1}
+				aria-setsize={buttons.length}
+			>
+				{actionButton}
+			</li>
+		) : (
+			actionButton
+		);
+	});
+
+	const Component = buttons.length > 1 ? "ul" : "div";
 
 	return (
-		<>
-			{buttons.length > 1 && templateTextId && (
-				<span
-					className={classNames(mainClasses.srOnly, "sr-only")}
-					id={`srOnly-${templateTextId}`}
-				>
-					{`Contains ${buttons.length} buttons or links`}
-				</span>
-			)}
-			<div
-				className={classnames(className, classes.buttons, containerClassName)}
-				style={containerStyle || {}}
-				role={buttons.length > 1 ? "group" : undefined}
-				aria-labelledby={
-					buttons.length > 1 && templateTextId
-						? `${templateTextId} srOnly-${templateTextId}`
-						: undefined
-				}
-				data-testid="action-buttons"
-			>
-				{buttonElements}
-			</div>
-		</>
+		<Component
+			className={classnames(className, classes.buttons, containerClassName)}
+			style={containerStyle || {}}
+			aria-labelledby={templateTextId}
+			data-testid="action-buttons"
+		>
+			{buttonElements}
+		</Component>
 	);
 };
 

--- a/src/common/Buttons/Buttons.module.css
+++ b/src/common/Buttons/Buttons.module.css
@@ -93,3 +93,7 @@ button.secondaryButton.button:disabled:focus {
 	border: 1px solid var(--cc-secondary-color-disabled);
 	background-color: var(--cc-white);
 }
+
+.buttonListItem {
+	width: 100%;
+}

--- a/src/common/Buttons/PrimaryButton.tsx
+++ b/src/common/Buttons/PrimaryButton.tsx
@@ -44,6 +44,7 @@ const PrimaryButton = forwardRef<HTMLButtonElement, PrimaryButtonProps>((props, 
 	return (
 		<ActionButtons
 			containerClassName={containerClassName}
+			buttonListItemClassName={classes.buttonListItem}
 			buttonClassName={classnames(
 				classes.primaryButton,
 				classes.actionButton,

--- a/src/common/Buttons/SecondaryButton.tsx
+++ b/src/common/Buttons/SecondaryButton.tsx
@@ -43,6 +43,7 @@ const SecondaryButton = forwardRef<HTMLButtonElement, SecondaryButtonProps>((pro
 	return (
 		<ActionButtons
 			containerClassName={containerClassName}
+			buttonListItemClassName={classes.buttonListItem}
 			buttonClassName={classnames(
 				classes.secondaryButton,
 				classes.actionButton,

--- a/src/common/ChatEvent.tsx
+++ b/src/common/ChatEvent.tsx
@@ -13,7 +13,7 @@ const ChatEvent: FC<ChatEventProps> = props => {
 	const { text, className, id } = props;
 
 	return (
-		<div className={classnames(classes.eventPill, className)} id={id}>
+		<div className={classnames(classes.eventPill, className)} id={id} aria-live="assertive">
 			<div className={classes.eventPillTextWrapper}>
 				<Typography variant="title2-semibold" component="div">
 					{text}

--- a/src/common/ChatEvent.tsx
+++ b/src/common/ChatEvent.tsx
@@ -2,6 +2,7 @@ import { FC } from "react";
 import classes from "./ChatEvent.module.css";
 import classnames from "classnames";
 import Typography from "./Typography/Typography";
+import { useLiveRegion, useMessageContext } from "src/messages/hooks";
 
 export interface ChatEventProps {
 	text?: string;
@@ -11,6 +12,12 @@ export interface ChatEventProps {
 
 const ChatEvent: FC<ChatEventProps> = props => {
 	const { text, className, id } = props;
+	const { "data-message-id": dataMessageId } = useMessageContext();
+
+	useLiveRegion({
+		messageType: "event",
+		data: { dataMessageId },
+	});
 
 	return (
 		<div className={classnames(classes.eventPill, className)} id={id} aria-live="assertive">

--- a/src/common/MessageHeader.tsx
+++ b/src/common/MessageHeader.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useEffect } from "react";
 import classes from "./MessageHeader.module.css";
 import classnames from "classnames";
 import mainClasses from "src/main.module.css";
@@ -18,7 +18,7 @@ interface MessageHeaderProps {
  * - Timestamp
  */
 const MessageHeader: FC<MessageHeaderProps> = props => {
-	const { message, config } = useMessageContext();
+	const { message, config, onSetHeaderInfo } = useMessageContext();
 
 	const directionMapping = config?.settings?.widgetSettings?.sourceDirectionMapping;
 
@@ -58,12 +58,19 @@ const MessageHeader: FC<MessageHeaderProps> = props => {
 		minute: "2-digit",
 	});
 
+	const sourceInfo = isUserMessage ? "You said:" : `${name} said:`;
+
+	useEffect(() => {
+		if (onSetHeaderInfo) {
+			onSetHeaderInfo(sourceInfo);
+		}
+	}, [onSetHeaderInfo, sourceInfo]);
+
 	return (
 		<header className={className} data-testid="message-header">
 			{props.enableAvatar && <Avatar />}
 			<span className={mainClasses.srOnly}>
-				{`At ${timestamp}, `}
-				{isUserMessage ? "You said:" : `${name} said:`}
+				At {timestamp}, {sourceInfo}
 			</span>
 			<Typography
 				variant="title2-regular"

--- a/src/common/MessageHeader.tsx
+++ b/src/common/MessageHeader.tsx
@@ -70,7 +70,7 @@ const MessageHeader: FC<MessageHeaderProps> = props => {
 		<header className={className} data-testid="message-header">
 			{props.enableAvatar && <Avatar />}
 			<span className={mainClasses.srOnly}>
-				At {timestamp}, {sourceInfo}
+				<span data-skip-live-region>At {timestamp},</span> {sourceInfo}
 			</span>
 			<Typography
 				variant="title2-regular"

--- a/src/messages/Audio/Audio.tsx
+++ b/src/messages/Audio/Audio.tsx
@@ -4,7 +4,7 @@ import classes from "./Audio.module.css";
 import classnames from "classnames";
 import Controls from "./Controls";
 import { OnProgressProps } from "react-player/base";
-import { useMessageContext } from "src/messages/hooks";
+import { useLiveRegion, useMessageContext } from "src/messages/hooks";
 import { getChannelPayload } from "src/utils";
 import { IWebchatAudioAttachment } from "@cognigy/socket-client";
 
@@ -49,6 +49,12 @@ const Audio: FC = () => {
 	const handleDuration = useCallback((duration: number) => {
 		setDuration(duration);
 	}, []);
+
+	useLiveRegion({
+		messageType: "audio",
+		data: { hasTranscript: !!altText },
+		validation: () => !!url,
+	});
 
 	if (!url) return null;
 

--- a/src/messages/DatePicker/DatePicker.tsx
+++ b/src/messages/DatePicker/DatePicker.tsx
@@ -137,11 +137,15 @@ const DatePicker: FC = () => {
 				disabled={shouldBeDisabled}
 				data-testid="button-open"
 				ref={openButtonRef}
+				aria-expanded={showPicker}
+				aria-controls={`webchat-plugin-date-picker-${message.id}`}
+				aria-haspopup="dialog"
 			>
 				{openText}
 			</PrimaryButton>
 			{showPicker && (
 				<div
+					id={`webchat-plugin-date-picker-${message.id}`}
 					className={classnames(classes.wrapper, "webchat-plugin-date-picker")}
 					onKeyDown={handleKeyDown}
 					tabIndex={0}

--- a/src/messages/File/File.tsx
+++ b/src/messages/File/File.tsx
@@ -10,10 +10,11 @@ import { getFileExtension, getFileName, getSizeLabel, isImageAttachment } from "
 const File: FC = props => {
 	const { message } = useMessageContext();
 	const attachments = message.data?.attachments as IUploadFileAttachmentData[];
+	const text = message.text;
 
 	useLiveRegion({
 		messageType: "file",
-		data: { attachments },
+		data: { text, attachments },
 		validation: () => !!attachments && attachments.length > 0,
 	});
 
@@ -123,7 +124,7 @@ const File: FC = props => {
 					</div>
 				)}
 			</div>
-			{message.text && <Text {...props} content={message.text} />}
+			{text && <Text {...props} content={text} ignoreLiveRegion />}
 		</>
 	);
 };

--- a/src/messages/File/File.tsx
+++ b/src/messages/File/File.tsx
@@ -2,17 +2,20 @@ import { FC } from "react";
 import classes from "./File.module.css";
 import classnames from "classnames";
 import { IUploadFileAttachmentData } from "@cognigy/socket-client";
-import { useMessageContext } from "src/messages/hooks";
+import { useLiveRegion, useMessageContext } from "src/messages/hooks";
 import { Typography } from "src/index";
 import { Text } from "src/messages";
-import { getFileExtension, getFileName } from "./helper";
-
-// The mime types we accept for image operations
-const VALID_IMAGE_MIME_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+import { getFileExtension, getFileName, getSizeLabel, isImageAttachment } from "./helper";
 
 const File: FC = props => {
 	const { message } = useMessageContext();
 	const attachments = message.data?.attachments as IUploadFileAttachmentData[];
+
+	useLiveRegion({
+		messageType: "file",
+		data: { attachments },
+		validation: () => !!attachments && attachments.length > 0,
+	});
 
 	if (!attachments || attachments.length === 0) return null;
 
@@ -21,20 +24,12 @@ const File: FC = props => {
 	const nonImages: IUploadFileAttachmentData[] = [];
 
 	attachments.forEach(attachment => {
-		if (VALID_IMAGE_MIME_TYPES.includes(attachment.mimeType)) {
+		if (isImageAttachment(attachment.mimeType)) {
 			images.push(attachment);
 		} else {
 			nonImages.push(attachment);
 		}
 	});
-
-	const getSizeLabel = (size: number) => {
-		if (size > 1000000) {
-			return `${(size / 1000000).toFixed(2)} MB`;
-		}
-
-		return `${(size / 1000).toFixed(2)} KB`;
-	};
 
 	return (
 		<>

--- a/src/messages/File/helper.ts
+++ b/src/messages/File/helper.ts
@@ -1,3 +1,6 @@
+const ONE_MB = 1000000;
+const ONE_KB = 1000;
+
 export const getFileName = (fileNameWithExtension: string) => {
 	const splitName = fileNameWithExtension.split(".");
 	if (splitName.length > 1) {
@@ -18,11 +21,11 @@ export const getFileExtension = (fileNameWithExtension: string) => {
 };
 
 export const getSizeLabel = (size: number) => {
-	if (size > 1000000) {
-		return `${(size / 1000000).toFixed(2)} MB`;
+	if (size > ONE_MB) {
+		return `${(size / ONE_MB).toFixed(2)} MB`;
 	}
 
-	return `${(size / 1000).toFixed(2)} KB`;
+	return `${(size / ONE_KB).toFixed(2)} KB`;
 };
 
 // The mime types we accept for image operations

--- a/src/messages/File/helper.ts
+++ b/src/messages/File/helper.ts
@@ -16,3 +16,18 @@ export const getFileExtension = (fileNameWithExtension: string) => {
 		return null;
 	}
 };
+
+export const getSizeLabel = (size: number) => {
+	if (size > 1000000) {
+		return `${(size / 1000000).toFixed(2)} MB`;
+	}
+
+	return `${(size / 1000).toFixed(2)} KB`;
+};
+
+// The mime types we accept for image operations
+export const VALID_IMAGE_MIME_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+export const isImageAttachment = (mimeType: string): boolean => {
+	return VALID_IMAGE_MIME_TYPES.includes(mimeType);
+};

--- a/src/messages/Gallery/Gallery.module.css
+++ b/src/messages/Gallery/Gallery.module.css
@@ -60,6 +60,10 @@
 	margin: 0px;
 }
 
+.slideItem .bottom .buttonListItem {
+	width: 100%;
+}
+
 /* 
 ** SWIPER MAIN
 ** The following styles are a porting from the original swiper/css and related modules.

--- a/src/messages/Gallery/Gallery.module.css
+++ b/src/messages/Gallery/Gallery.module.css
@@ -47,7 +47,7 @@
 	border-bottom-right-radius: 0px;
 }
 
-.slideItem .top h2 {
+.slideItem .top h3 {
 	position: absolute;
 	margin: 0px;
 	margin-inline-start: 8px;

--- a/src/messages/Gallery/Gallery.tsx
+++ b/src/messages/Gallery/Gallery.tsx
@@ -10,7 +10,7 @@ import GalleryItem from "./GalleryItem";
 import { IWebchatAttachmentElement, IWebchatTemplateAttachment } from "@cognigy/socket-client";
 
 const Gallery: FC = () => {
-	const { message, config } = useMessageContext();
+	const { message, config, "data-message-id": dataMessageId } = useMessageContext();
 	const payload = getChannelPayload(message, config);
 	const { elements } =
 		(payload?.message?.attachment as IWebchatTemplateAttachment)?.payload || {};
@@ -37,6 +37,16 @@ const Gallery: FC = () => {
 			}, 200);
 		}
 	}, [carouselContentId, config?.settings?.widgetSettings?.enableAutoFocus]);
+
+	// Remove the default `aria-live="polite"` attribute added by React-Swiper to the `.swiper-wrapper`.
+	// This ensures that the gallery message does not interfere with other live region announcements.
+	useEffect(() => {
+		const galleryMessage = document.querySelector(`[data-message-id="${dataMessageId}"]`);
+		const swiperWrapper = galleryMessage?.querySelector(".swiper-wrapper");
+		if (swiperWrapper) {
+			swiperWrapper.removeAttribute("aria-live");
+		}
+	}, [dataMessageId]);
 
 	if (!elements || elements?.length === 0) return null;
 

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -30,6 +30,9 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 
 	const shouldBeDisabled = messageParams?.isConversationEnded;
 
+	const opensInNewTab =
+		config?.settings.customTranslations?.ariaLabels?.opensInNewTab ?? "Opens in new tab";
+
 	const handleClick = () => {
 		if (!default_action?.url) return;
 
@@ -48,8 +51,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 			handleClick();
 		}
 	};
-	const opensInNewTab =
-		config?.settings.customTranslations?.ariaLabels?.opensInNewTab ?? "Opens in new tab";
+
 	return (
 		<div className={classnames("webchat-carousel-template-frame", classes.slideItem)}>
 			<div className={classnames(classes.top, hasExtraInfo && classes.hasExtraInfo)}>
@@ -65,7 +67,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 				) : (
 					<img
 						src={image_url}
-						alt={image_alt_text || "Attachment Image"}
+						alt={image_alt_text || ""}
 						className={classes.slideImage}
 						onError={() => setImageBroken(true)}
 					/>

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -97,6 +97,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 								buttonClasses.actionButton,
 								"webchat-carousel-template-button",
 							)}
+							buttonListItemClassName={classes.buttonListItem}
 							payload={buttons}
 							action={shouldBeDisabled ? undefined : action}
 							config={config}

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -55,7 +55,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 			<div className={classnames(classes.top, hasExtraInfo && classes.hasExtraInfo)}>
 				<Typography
 					variant="body-semibold"
-					component="h2"
+					component="h3"
 					dangerouslySetInnerHTML={{ __html: titleHtml }}
 					className="webchat-carousel-template-title"
 					id={titleId}

--- a/src/messages/Gallery/helper.ts
+++ b/src/messages/Gallery/helper.ts
@@ -1,10 +1,10 @@
 import { IWebchatAttachmentElement } from "@cognigy/socket-client";
-import { sanitizeHTML } from "src/sanitize";
+import { sanitizeContent } from "src/sanitize";
 import { getWebchatButtonLabel } from "src/utils";
 
 export interface GalleryLiveContent {
 	slideText: string;
-	buttonLabels: string[];
+	buttonLabels: string[] | undefined;
 }
 
 /**
@@ -37,17 +37,4 @@ export const getGalleryContent = (
 			buttonLabels,
 		};
 	});
-};
-
-/**
- * Sanitizes content if sanitization is enabled.
- * @param content - The content to sanitize.
- * @param isSanitizeEnabled - Whether to sanitize the content.
- * @returns The sanitized or raw content.
- */
-const sanitizeContent = (content: string | undefined, isSanitizeEnabled: boolean): string => {
-	if (!content) {
-		return "";
-	}
-	return isSanitizeEnabled ? sanitizeHTML(content) : content;
 };

--- a/src/messages/Gallery/helper.ts
+++ b/src/messages/Gallery/helper.ts
@@ -1,0 +1,53 @@
+import { IWebchatAttachmentElement } from "@cognigy/socket-client";
+import { sanitizeHTML } from "src/sanitize";
+import { getWebchatButtonLabel } from "src/utils";
+
+export interface GalleryLiveContent {
+	slideText: string;
+	buttonLabels: string[];
+}
+
+/**
+ * Get text and buttons in a gallery, to be used during live region announcement.
+ * @param elements - The gallery elements to process.
+ * @param isSanitizeEnabled - Whether to sanitize HTML content.
+ * @returns An array of objects containing slide text and button labels.
+ */
+export const getGalleryContent = (
+	elements: IWebchatAttachmentElement[] | undefined,
+	isSanitizeEnabled: boolean,
+): GalleryLiveContent[] => {
+	if (!elements || elements.length === 0) {
+		return [];
+	}
+
+	return elements.map((element: IWebchatAttachmentElement) => {
+		const title = sanitizeContent(element.title, isSanitizeEnabled);
+
+		const subtitle = sanitizeContent(element.subtitle, isSanitizeEnabled);
+
+		const buttonLabels = (element.buttons || []).map(button =>
+			sanitizeContent(getWebchatButtonLabel(button), isSanitizeEnabled),
+		);
+
+		const slideText = `${title}. ${subtitle}.`;
+
+		return {
+			slideText,
+			buttonLabels,
+		};
+	});
+};
+
+/**
+ * Sanitizes content if sanitization is enabled.
+ * @param content - The content to sanitize.
+ * @param isSanitizeEnabled - Whether to sanitize the content.
+ * @returns The sanitized or raw content.
+ */
+const sanitizeContent = (content: string | undefined, isSanitizeEnabled: boolean): string => {
+	if (!content) {
+		return "";
+	}
+	return isSanitizeEnabled ? sanitizeHTML(content) : content;
+};

--- a/src/messages/Gallery/helper.ts
+++ b/src/messages/Gallery/helper.ts
@@ -30,7 +30,7 @@ export const getGalleryContent = (
 			sanitizeContent(getWebchatButtonLabel(button), isSanitizeEnabled),
 		);
 
-		const slideText = `${title}. ${subtitle}.`;
+		const slideText = `${title}. ${subtitle}`;
 
 		return {
 			slideText,

--- a/src/messages/Image/ImageThumb.tsx
+++ b/src/messages/Image/ImageThumb.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useState } from "react";
 import classes from "./Image.module.css";
 import classnames from "classnames/bind";
 import { useImageMessageContext } from "./hooks";
-import { useMessageContext } from "src/messages/hooks";
+import { useLiveRegion, useMessageContext } from "src/messages/hooks";
 import { PrimaryButton } from "src/common/Buttons";
 import { DownloadIcon } from "src/assets/svg";
 
@@ -35,6 +35,9 @@ const ImageThumb = forwardRef((_props, ref) => {
 	const viewImageInFullsizeLabel =
 		config?.settings.customTranslations?.ariaLabels?.viewImageInFullsize ||
 		"View full-size image";
+
+	useLiveRegion({ messageType: "image", data: { isDownloadable, altText } });
+
 	return (
 		<div className={wrapperClasses}>
 			<div
@@ -50,7 +53,7 @@ const ImageThumb = forwardRef((_props, ref) => {
 				{isImageBroken ? (
 					<span className={classes.brokenImage} />
 				) : (
-					<img src={url} alt={altText} onError={() => setImageBroken(true)} />
+					<img src={url} alt={altText || ""} onError={() => setImageBroken(true)} />
 				)}
 			</div>
 			{button && (

--- a/src/messages/List/List.tsx
+++ b/src/messages/List/List.tsx
@@ -8,19 +8,13 @@ import { PrimaryButton } from "src/common/Buttons";
 import { getChannelPayload } from "src/utils";
 import { IWebchatAttachmentElement, IWebchatTemplateAttachment } from "@cognigy/socket-client";
 
-interface IListProps {
-	onSetLiveRegionText?: (text: string) => void;
-}
-
-const List: FC<IListProps> = props => {
+const List: FC = () => {
 	const { message, messageParams, config, action, onEmitAnalytics } = useMessageContext();
 	const payload = getChannelPayload(message, config);
 
 	const [listItemLiveRegionLabels, setListItemLiveRegionLabels] = useState<
 		Record<number, string>
 	>({});
-
-	const { onSetLiveRegionText } = props;
 
 	const { elements, top_element_style, buttons } =
 		(payload?.message?.attachment as IWebchatTemplateAttachment)?.payload || {};
@@ -56,7 +50,6 @@ const List: FC<IListProps> = props => {
 	useLiveRegion({
 		messageType: "list",
 		data: listItemLiveRegionLabels,
-		onSetLiveRegionText,
 		validation: () => elements?.length === Object.keys(listItemLiveRegionLabels).length,
 	});
 

--- a/src/messages/List/List.tsx
+++ b/src/messages/List/List.tsx
@@ -1,11 +1,11 @@
-import { FC, Fragment, useCallback, useEffect, useRef, useState } from "react";
+import { FC, Fragment, useCallback, useEffect, useState } from "react";
 import ListItem from "./ListItem";
-import { useMessageContext, useRandomId } from "src/messages/hooks";
+import { useLiveRegion, useMessageContext, useRandomId } from "src/messages/hooks";
 import mainclasses from "src/main.module.css";
 import classes from "./List.module.css";
 import classnames from "classnames";
 import { PrimaryButton } from "src/common/Buttons";
-import { getChannelPayload, getLiveRegionContent } from "src/utils";
+import { getChannelPayload } from "src/utils";
 import { IWebchatAttachmentElement, IWebchatTemplateAttachment } from "@cognigy/socket-client";
 
 interface IListProps {
@@ -19,8 +19,6 @@ const List: FC<IListProps> = props => {
 	const [listItemLiveRegionLabels, setListItemLiveRegionLabels] = useState<
 		Record<number, string>
 	>({});
-
-	const previousLiveContentRef = useRef<string | undefined>(undefined);
 
 	const { onSetLiveRegionText } = props;
 
@@ -55,19 +53,12 @@ const List: FC<IListProps> = props => {
 		}, 200);
 	}, [config?.settings?.widgetSettings?.enableAutoFocus, listTemplateId]);
 
-	useEffect(() => {
-		const liveRegionText = getLiveRegionContent("list", listItemLiveRegionLabels);
-
-		if (
-			onSetLiveRegionText &&
-			liveRegionText &&
-			liveRegionText !== previousLiveContentRef.current &&
-			elements?.length === Object.keys(listItemLiveRegionLabels).length
-		) {
-			onSetLiveRegionText(liveRegionText);
-			previousLiveContentRef.current = liveRegionText;
-		}
-	}, [onSetLiveRegionText, listItemLiveRegionLabels, elements]);
+	useLiveRegion({
+		messageType: "list",
+		data: listItemLiveRegionLabels,
+		onSetLiveRegionText,
+		validation: () => elements?.length === Object.keys(listItemLiveRegionLabels).length,
+	});
 
 	const handleListItemLiveRegionLabel = useCallback((index: number, label: string) => {
 		setListItemLiveRegionLabels(prev => {

--- a/src/messages/List/ListItem.tsx
+++ b/src/messages/List/ListItem.tsx
@@ -69,7 +69,7 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 				{titleHtml && (
 					<Typography
 						variant={isHeaderElement ? "h2-semibold" : "title1-semibold"}
-						component="h2"
+						component="h3"
 						dangerouslySetInnerHTML={{ __html: titleHtml }}
 						className={classnames(
 							isHeaderElement

--- a/src/messages/List/ListItem.tsx
+++ b/src/messages/List/ListItem.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, KeyboardEvent } from "react";
+import { FC, useMemo, KeyboardEvent, useEffect } from "react";
 import classes from "./List.module.css";
 import { useMessageContext, useRandomId } from "src/messages/hooks";
 import { sanitizeHTML } from "src/sanitize";
@@ -9,9 +9,17 @@ import { sanitizeUrl } from "@braintree/sanitize-url";
 import { IWebchatAttachmentElement } from "@cognigy/socket-client";
 import { Typography } from "src/index";
 
-const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boolean }> = props => {
+interface IListItemProps {
+	element: IWebchatAttachmentElement;
+	isHeaderElement?: boolean;
+	headingLevel?: "h3" | "h4";
+	id: string;
+	onSetScreenReaderLabel?: (text: string) => void;
+}
+
+const ListItem: FC<IListItemProps> = props => {
 	const { action, config, onEmitAnalytics, messageParams } = useMessageContext();
-	const { element, isHeaderElement } = props;
+	const { element, isHeaderElement, headingLevel, id, onSetScreenReaderLabel } = props;
 	const { title, subtitle, image_url, image_alt_text, default_action, buttons } = element;
 	const button = buttons && buttons?.[0];
 
@@ -48,6 +56,12 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 		? classnames("webchat-list-template-header", classes.headerContentWrapper)
 		: classnames("webchat-list-template-element", classes.listItemWrapper);
 
+	useEffect(() => {
+		if (onSetScreenReaderLabel && titleHtml) {
+			onSetScreenReaderLabel(titleHtml);
+		}
+	}, [onSetScreenReaderLabel, titleHtml]);
+
 	const renderImage = useMemo(() => {
 		if (!image_url) return null;
 
@@ -69,7 +83,7 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 				{titleHtml && (
 					<Typography
 						variant={isHeaderElement ? "h2-semibold" : "title1-semibold"}
-						component="h3"
+						component={headingLevel}
 						dangerouslySetInnerHTML={{ __html: titleHtml }}
 						className={classnames(
 							isHeaderElement
@@ -77,6 +91,7 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 								: "webchat-list-template-element-title",
 							subtitleHtml ? classes.itemTitleWithSubtitle : classes.itemTitle,
 						)}
+						id={isHeaderElement ? `listHeader-${id}` : `listItemHeader-${id}`}
 					/>
 				)}
 				{subtitleHtml && (
@@ -94,19 +109,23 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 				)}
 			</>
 		);
-	}, [subtitleHtml, subtitleId, titleHtml, isHeaderElement]);
+	}, [subtitleHtml, subtitleId, titleHtml, isHeaderElement, headingLevel, id]);
 
 	const opensInNewTabLabel =
 		config?.settings.customTranslations?.ariaLabels?.opensInNewTab || "Opens in new tab";
+
+	const Component = isHeaderElement ? "div" : "li";
+
 	return (
-		<div
-			role="listitem"
+		<Component
+			role={isHeaderElement ? undefined : "listitem"}
 			className={rootClasses}
 			style={{
 				backgroundImage:
 					isHeaderElement && image_url ? getBackgroundImage(image_url) : undefined,
 			}}
 			data-testid={isHeaderElement ? "header-image" : "list-item"}
+			id={id}
 		>
 			<div
 				className={contentClasses}
@@ -163,7 +182,7 @@ const ListItem: FC<{ element: IWebchatAttachmentElement; isHeaderElement?: boole
 					onEmitAnalytics={onEmitAnalytics}
 				/>
 			)}
-		</div>
+		</Component>
 	);
 };
 

--- a/src/messages/Message.tsx
+++ b/src/messages/Message.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react";
+import { FC, useMemo, useState } from "react";
 import classnames from "classnames";
 
 import MessageHeader from "../common/MessageHeader";
@@ -70,6 +70,8 @@ const Message: FC<MessageProps> = props => {
 
 	const showHeader = !shouldCollate && !isFullscreen && !isEventMessage(message);
 
+	const [headerInfo, setHeaderInfo] = useState<string>("");
+
 	const rootClassName = classnames(
 		"webchat-message-row",
 		message.source,
@@ -123,6 +125,8 @@ const Message: FC<MessageProps> = props => {
 			openXAppOverlay={openXAppOverlay}
 			data-message-id={dataMessageId}
 			onSetLiveRegionText={onSetLiveRegionText}
+			headerInfo={headerInfo}
+			onSetHeaderInfo={setHeaderInfo}
 		>
 			<article
 				{...(message.id ? { id: message.id } : {})}

--- a/src/messages/Message.tsx
+++ b/src/messages/Message.tsx
@@ -34,6 +34,7 @@ export interface MessageProps {
 		messageId: string,
 		animationState: IStreamingMessage["animationState"],
 	) => void;
+	onSetLiveRegionContent?: (text: string) => void;
 }
 
 const defaultCollate = new CollateMessage();
@@ -103,6 +104,7 @@ const Message: FC<MessageProps> = props => {
 					theme={props.theme}
 					attributes={{ styles: { flexGrow: 1, minHeight: 0 } }}
 					onSetMessageAnimated={props.onSetMessageAnimated}
+					onSetLiveRegionContent={props.onSetLiveRegionContent}
 				/>
 			);
 		}
@@ -133,6 +135,7 @@ const Message: FC<MessageProps> = props => {
 							prevMessage={prevMessage}
 							theme={props.theme}
 							onSetMessageAnimated={props.onSetMessageAnimated}
+							onSetLiveRegionContent={props.onSetLiveRegionContent}
 						/>
 					) : null,
 				)}

--- a/src/messages/Message.tsx
+++ b/src/messages/Message.tsx
@@ -34,7 +34,8 @@ export interface MessageProps {
 		messageId: string,
 		animationState: IStreamingMessage["animationState"],
 	) => void;
-	onSetLiveRegionText?: (text: string) => void;
+	onSetLiveRegionText?: (id: string, text: string) => void;
+	"data-message-id"?: string;
 }
 
 const defaultCollate = new CollateMessage();
@@ -56,6 +57,7 @@ const Message: FC<MessageProps> = props => {
 		onSetLiveRegionText,
 		plugins,
 		prevMessage,
+		"data-message-id": dataMessageId,
 	} = props;
 
 	// Get the collation instance from the context
@@ -119,9 +121,14 @@ const Message: FC<MessageProps> = props => {
 			messageParams={messageParams}
 			onEmitAnalytics={onEmitAnalytics}
 			openXAppOverlay={openXAppOverlay}
+			data-message-id={dataMessageId}
 			onSetLiveRegionText={onSetLiveRegionText}
 		>
-			<article {...(message.id ? { id: message.id } : {})} className={rootClassName}>
+			<article
+				{...(message.id ? { id: message.id } : {})}
+				className={rootClassName}
+				data-message-id={dataMessageId}
+			>
 				{showHeader && <MessageHeader enableAvatar={message.source !== "user"} />}
 				{matchedPlugins.map((plugin, index) =>
 					plugin.component ? (

--- a/src/messages/Message.tsx
+++ b/src/messages/Message.tsx
@@ -106,7 +106,6 @@ const Message: FC<MessageProps> = props => {
 					theme={props.theme}
 					attributes={{ styles: { flexGrow: 1, minHeight: 0 } }}
 					onSetMessageAnimated={props.onSetMessageAnimated}
-					onSetLiveRegionText={props.onSetLiveRegionText}
 				/>
 			);
 		}
@@ -120,6 +119,7 @@ const Message: FC<MessageProps> = props => {
 			messageParams={messageParams}
 			onEmitAnalytics={onEmitAnalytics}
 			openXAppOverlay={openXAppOverlay}
+			onSetLiveRegionText={onSetLiveRegionText}
 		>
 			<article {...(message.id ? { id: message.id } : {})} className={rootClassName}>
 				{showHeader && <MessageHeader enableAvatar={message.source !== "user"} />}
@@ -137,7 +137,6 @@ const Message: FC<MessageProps> = props => {
 							prevMessage={prevMessage}
 							theme={props.theme}
 							onSetMessageAnimated={onSetMessageAnimated}
-							onSetLiveRegionText={onSetLiveRegionText}
 						/>
 					) : null,
 				)}

--- a/src/messages/Message.tsx
+++ b/src/messages/Message.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from "react";
+import { FC, useMemo, useState, useEffect } from "react";
 import classnames from "classnames";
 
 import MessageHeader from "../common/MessageHeader";
@@ -70,7 +70,13 @@ const Message: FC<MessageProps> = props => {
 
 	const showHeader = !shouldCollate && !isFullscreen && !isEventMessage(message);
 
-	const [headerInfo, setHeaderInfo] = useState<string>("");
+	const [headerInfo, setHeaderInfo] = useState<string | null>("");
+
+	useEffect(() => {
+		if (!showHeader) {
+			setHeaderInfo(null);
+		}
+	}, [showHeader]);
 
 	const rootClassName = classnames(
 		"webchat-message-row",

--- a/src/messages/Message.tsx
+++ b/src/messages/Message.tsx
@@ -34,7 +34,7 @@ export interface MessageProps {
 		messageId: string,
 		animationState: IStreamingMessage["animationState"],
 	) => void;
-	onSetLiveRegionContent?: (text: string) => void;
+	onSetLiveRegionText?: (text: string) => void;
 }
 
 const defaultCollate = new CollateMessage();
@@ -104,7 +104,7 @@ const Message: FC<MessageProps> = props => {
 					theme={props.theme}
 					attributes={{ styles: { flexGrow: 1, minHeight: 0 } }}
 					onSetMessageAnimated={props.onSetMessageAnimated}
-					onSetLiveRegionContent={props.onSetLiveRegionContent}
+					onSetLiveRegionText={props.onSetLiveRegionText}
 				/>
 			);
 		}
@@ -135,7 +135,7 @@ const Message: FC<MessageProps> = props => {
 							prevMessage={prevMessage}
 							theme={props.theme}
 							onSetMessageAnimated={props.onSetMessageAnimated}
-							onSetLiveRegionContent={props.onSetLiveRegionContent}
+							onSetLiveRegionText={props.onSetLiveRegionText}
 						/>
 					) : null,
 				)}

--- a/src/messages/Message.tsx
+++ b/src/messages/Message.tsx
@@ -52,6 +52,8 @@ const Message: FC<MessageProps> = props => {
 		onEmitAnalytics,
 		onSetFullscreen,
 		openXAppOverlay,
+		onSetMessageAnimated,
+		onSetLiveRegionText,
 		plugins,
 		prevMessage,
 	} = props;
@@ -134,8 +136,8 @@ const Message: FC<MessageProps> = props => {
 							onSetFullscreen={onSetFullscreen}
 							prevMessage={prevMessage}
 							theme={props.theme}
-							onSetMessageAnimated={props.onSetMessageAnimated}
-							onSetLiveRegionText={props.onSetLiveRegionText}
+							onSetMessageAnimated={onSetMessageAnimated}
+							onSetLiveRegionText={onSetLiveRegionText}
 						/>
 					) : null,
 				)}

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -76,6 +76,7 @@ const Text: FC<TextProps> = props => {
 		validation: () => !onRegisterLiveRegionText,
 	});
 
+	// Text content for live screen reader announcement
 	useEffect(() => {
 		if (onRegisterLiveRegionText) {
 			onRegisterLiveRegionText(__html);

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -24,7 +24,12 @@ interface TextProps {
 }
 
 const Text: FC<TextProps> = props => {
-	const { message, config, onSetLiveRegionText } = useMessageContext();
+	const {
+		message,
+		config,
+		onSetLiveRegionText,
+		"data-message-id": dataMessageId,
+	} = useMessageContext();
 	const { onSetScreenReaderBtnLabel } = props;
 	const text = message?.text;
 	const source = message?.source;
@@ -74,11 +79,16 @@ const Text: FC<TextProps> = props => {
 	useEffect(() => {
 		if (onSetScreenReaderBtnLabel) {
 			onSetScreenReaderBtnLabel(__html);
-		} else if (onSetLiveRegionText && __html && __html !== previousLiveContentRef.current) {
-			onSetLiveRegionText(__html);
+		} else if (
+			onSetLiveRegionText &&
+			__html &&
+			__html !== previousLiveContentRef.current &&
+			dataMessageId
+		) {
+			onSetLiveRegionText(dataMessageId, __html);
 			previousLiveContentRef.current = __html;
 		}
-	}, [__html, onSetLiveRegionText, onSetScreenReaderBtnLabel]);
+	}, [__html, onSetLiveRegionText, onSetScreenReaderBtnLabel, dataMessageId]);
 
 	return (
 		<ChatBubble>

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -20,13 +20,12 @@ interface TextProps {
 		messageId: string,
 		animationState: IStreamingMessage["animationState"],
 	) => void;
-	onSetLiveRegionText?: (text: string) => void;
 	onSetScreenReaderBtnLabel?: (text: string) => void;
 }
 
 const Text: FC<TextProps> = props => {
-	const { message, config } = useMessageContext();
-	const { onSetLiveRegionText, onSetScreenReaderBtnLabel } = props;
+	const { message, config, onSetLiveRegionText } = useMessageContext();
+	const { onSetScreenReaderBtnLabel } = props;
 	const text = message?.text;
 	const source = message?.source;
 	const content = props.content || text || "";

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -20,16 +20,13 @@ interface TextProps {
 		messageId: string,
 		animationState: IStreamingMessage["animationState"],
 	) => void;
-	onSetScreenReaderBtnLabel?: (text: string) => void;
+	onRegisterLiveRegionText?: (text: string) => void;
 }
 
 const Text: FC<TextProps> = props => {
-	const {
-		message,
-		config,
-	} = useMessageContext();
+	const { message, config } = useMessageContext();
 
-	const { onSetScreenReaderBtnLabel } = props;
+	const { onRegisterLiveRegionText } = props;
 	const text = message?.text;
 	const source = message?.source;
 	const content = props.content || text || "";
@@ -37,7 +34,6 @@ const Text: FC<TextProps> = props => {
 		(message as IStreamingMessage)?.animationState === "start" ||
 		(message as IStreamingMessage)?.animationState === "animating" ||
 		false;
-
 
 	const renderMarkdown =
 		config?.settings?.behavior?.renderMarkdown && (source === "bot" || source === "engagement");
@@ -76,15 +72,15 @@ const Text: FC<TextProps> = props => {
 
 	useLiveRegion({
 		messageType: "text",
-		data: { text: __html},
-		validation: () => !onSetScreenReaderBtnLabel,
-	})
+		data: { text: __html },
+		validation: () => !onRegisterLiveRegionText,
+	});
 
 	useEffect(() => {
-		if (onSetScreenReaderBtnLabel) {
-			onSetScreenReaderBtnLabel(__html);
-		} 
-	}, [__html, onSetScreenReaderBtnLabel]);
+		if (onRegisterLiveRegionText) {
+			onRegisterLiveRegionText(__html);
+		}
+	}, [__html, onRegisterLiveRegionText]);
 
 	return (
 		<ChatBubble>

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -20,13 +20,12 @@ interface TextProps {
 		messageId: string,
 		animationState: IStreamingMessage["animationState"],
 	) => void;
-	onRegisterLiveRegionText?: (text: string) => void;
+	ignoreLiveRegion?: boolean;
 }
 
 const Text: FC<TextProps> = props => {
 	const { message, config } = useMessageContext();
 
-	const { onRegisterLiveRegionText } = props;
 	const text = message?.text;
 	const source = message?.source;
 	const content = props.content || text || "";
@@ -73,15 +72,8 @@ const Text: FC<TextProps> = props => {
 	useLiveRegion({
 		messageType: "text",
 		data: { text: __html },
-		validation: () => !onRegisterLiveRegionText,
+		validation: () => !props.ignoreLiveRegion,
 	});
-
-	// Text content for live screen reader announcement
-	useEffect(() => {
-		if (onRegisterLiveRegionText) {
-			onRegisterLiveRegionText(__html);
-		}
-	}, [__html, onRegisterLiveRegionText]);
 
 	return (
 		<ChatBubble>

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -20,13 +20,13 @@ interface TextProps {
 		messageId: string,
 		animationState: IStreamingMessage["animationState"],
 	) => void;
-	onSetLiveRegionContent?: (text: string) => void;
+	onSetLiveRegionText?: (text: string) => void;
 	onSetScreenReaderBtnLabel?: (text: string) => void;
 }
 
 const Text: FC<TextProps> = props => {
 	const { message, config } = useMessageContext();
-	const { onSetLiveRegionContent, onSetScreenReaderBtnLabel } = props;
+	const { onSetLiveRegionText, onSetScreenReaderBtnLabel } = props;
 	const text = message?.text;
 	const source = message?.source;
 	const content = props.content || text || "";
@@ -75,11 +75,11 @@ const Text: FC<TextProps> = props => {
 	useEffect(() => {
 		if (onSetScreenReaderBtnLabel) {
 			onSetScreenReaderBtnLabel(__html);
-		} else if (onSetLiveRegionContent && __html && __html !== previousLiveContentRef.current) {
-			onSetLiveRegionContent(__html);
+		} else if (onSetLiveRegionText && __html && __html !== previousLiveContentRef.current) {
+			onSetLiveRegionText(__html);
 			previousLiveContentRef.current = __html;
 		}
-	}, [__html, onSetLiveRegionContent, onSetScreenReaderBtnLabel]);
+	}, [__html, onSetLiveRegionText, onSetScreenReaderBtnLabel]);
 
 	return (
 		<ChatBubble>

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -1,6 +1,6 @@
-import { FC, useEffect, useMemo, useRef, useState } from "react";
+import { FC, useEffect, useMemo, useState } from "react";
 import classNames from "classnames";
-import { useMessageContext } from "../hooks";
+import { useLiveRegion, useMessageContext } from "../hooks";
 import ChatBubble from "../../common/ChatBubble";
 import { replaceUrlsWithHTMLanchorElem } from "src/utils";
 import { sanitizeHTML } from "src/sanitize";
@@ -27,9 +27,8 @@ const Text: FC<TextProps> = props => {
 	const {
 		message,
 		config,
-		onSetLiveRegionText,
-		"data-message-id": dataMessageId,
 	} = useMessageContext();
+
 	const { onSetScreenReaderBtnLabel } = props;
 	const text = message?.text;
 	const source = message?.source;
@@ -39,7 +38,6 @@ const Text: FC<TextProps> = props => {
 		(message as IStreamingMessage)?.animationState === "animating" ||
 		false;
 
-	const previousLiveContentRef = useRef<string | undefined>(undefined);
 
 	const renderMarkdown =
 		config?.settings?.behavior?.renderMarkdown && (source === "bot" || source === "engagement");
@@ -76,19 +74,17 @@ const Text: FC<TextProps> = props => {
 		? enhancedURLsText
 		: sanitizeHTML(enhancedURLsText);
 
+	useLiveRegion({
+		messageType: "text",
+		data: { text: __html},
+		validation: () => !onSetScreenReaderBtnLabel,
+	})
+
 	useEffect(() => {
 		if (onSetScreenReaderBtnLabel) {
 			onSetScreenReaderBtnLabel(__html);
-		} else if (
-			onSetLiveRegionText &&
-			__html &&
-			__html !== previousLiveContentRef.current &&
-			dataMessageId
-		) {
-			onSetLiveRegionText(dataMessageId, __html);
-			previousLiveContentRef.current = __html;
-		}
-	}, [__html, onSetLiveRegionText, onSetScreenReaderBtnLabel, dataMessageId]);
+		} 
+	}, [__html, onSetScreenReaderBtnLabel]);
 
 	return (
 		<ChatBubble>

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -27,8 +27,8 @@ interface ITextWithButtonsProps {
  */
 const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 	const { onSetMessageAnimated } = props;
-	const [textContent, setScreenReaderTextContent] = useState<string>("");
-	const [buttonLabels, setScreenReaderButtonLabels] = useState<string[]>([]);
+	const [liveRegionTextContent, setLiveRegionTextContent] = useState<string>("");
+	const [liveRegionButtonLabels, setLiveRegionButtonLabels] = useState<string[]>([]);
 
 	const { action, message, config, onEmitAnalytics, messageParams, openXAppOverlay } =
 		useMessageContext();
@@ -68,8 +68,8 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 
 	useLiveRegion({
 		messageType: "textWithButtons",
-		data: { textContent, buttonLabels },
-		validation: () => buttonLabels.length === buttons.length,
+		data: { text: liveRegionTextContent, buttons: liveRegionButtonLabels },
+		validation: () => liveRegionButtonLabels.length === buttons.length,
 	});
 
 	const stillAnimating =
@@ -100,7 +100,7 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 					content={text}
 					className={`webchat-${classType}-template-header`}
 					id={webchatButtonTemplateTextId}
-					onSetScreenReaderBtnLabel={setScreenReaderTextContent}
+					onRegisterLiveRegionText={setLiveRegionTextContent}
 				/>
 			)}
 
@@ -122,8 +122,8 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 					onEmitAnalytics={onEmitAnalytics}
 					templateTextId={webchatButtonTemplateTextId}
 					openXAppOverlay={openXAppOverlay}
-					onRegisterScreenReaderLabel={label =>
-						setScreenReaderButtonLabels(prev => [...prev, label])
+					onRegisterLiveRegionButtons={label =>
+						setLiveRegionButtonLabels(prev => [...prev, label])
 					}
 				/>
 			)}

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -42,7 +42,10 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 
 	const attachments = payload?.message?.attachment as IWebchatTemplateAttachment;
 	const text = attachments?.payload?.text || payload?.message?.text || "";
-	const buttons = attachments?.payload?.buttons || payload?.message?.quick_replies || [];
+	const buttons = useMemo(
+		() => attachments?.payload?.buttons || payload?.message?.quick_replies || [],
+		[attachments?.payload?.buttons, payload?.message?.quick_replies],
+	);
 
 	useEffect(() => {
 		if (

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -5,7 +5,7 @@ import { Text } from "src/messages";
 import classes from "./TextWithButtons.module.css";
 import { useMessageContext, useRandomId } from "../hooks";
 
-import { getChannelPayload } from "src/utils";
+import { getChannelPayload, getLiveRegionContent } from "src/utils";
 import ActionButtons from "src/common/ActionButtons/ActionButtons";
 import { IWebchatTemplateAttachment } from "@cognigy/socket-client";
 import classNames from "classnames";
@@ -69,14 +69,13 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 	]);
 
 	useEffect(() => {
-		const getLiveRegionContent = () => {
-			if (!!textContent && buttonLabels.length > 0 && buttonLabels.length === buttons.length) {
-				return `${textContent}${buttonLabels.length > 0 ? " Available options: " + buttonLabels.join(", ") : ""}`;
-			}
-		};
-
-		const liveRegionContent = getLiveRegionContent();
-		if (liveRegionContent && liveRegionContent !== previousLiveContentRef.current) {
+		const data = { textContent, buttonLabels };
+		const liveRegionContent = getLiveRegionContent("textWithButtons", data);
+		if (
+			liveRegionContent &&
+			liveRegionContent !== previousLiveContentRef.current &&
+			buttonLabels.length === buttons.length
+		) {
 			onSetLiveRegionText?.(liveRegionContent);
 			previousLiveContentRef.current = liveRegionContent;
 		}

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -16,7 +16,6 @@ interface ITextWithButtonsProps {
 		messageId: string,
 		animationState: IStreamingMessage["animationState"],
 	) => void;
-	onSetLiveRegionText?: (text: string) => void;
 }
 
 /**
@@ -27,7 +26,7 @@ interface ITextWithButtonsProps {
  * - QR buttons get disabled when there is a reply in chat from the user
  */
 const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
-	const { onSetMessageAnimated, onSetLiveRegionText } = props;
+	const { onSetMessageAnimated } = props;
 	const [textContent, setScreenReaderTextContent] = useState<string>("");
 	const [buttonLabels, setScreenReaderButtonLabels] = useState<string[]>([]);
 
@@ -70,7 +69,6 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 	useLiveRegion({
 		messageType: "textWithButtons",
 		data: { textContent, buttonLabels },
-		onSetLiveRegionText,
 		validation: () => buttonLabels.length === buttons.length,
 	});
 

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -1,11 +1,11 @@
-import { FC, useEffect, useRef, useState } from "react";
+import { FC, useEffect, useState } from "react";
 
 import { Text } from "src/messages";
 
 import classes from "./TextWithButtons.module.css";
-import { useMessageContext, useRandomId } from "../hooks";
+import { useLiveRegion, useMessageContext, useRandomId } from "../hooks";
 
-import { getChannelPayload, getLiveRegionContent } from "src/utils";
+import { getChannelPayload } from "src/utils";
 import ActionButtons from "src/common/ActionButtons/ActionButtons";
 import { IWebchatTemplateAttachment } from "@cognigy/socket-client";
 import classNames from "classnames";
@@ -30,7 +30,6 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 	const { onSetMessageAnimated, onSetLiveRegionText } = props;
 	const [textContent, setScreenReaderTextContent] = useState<string>("");
 	const [buttonLabels, setScreenReaderButtonLabels] = useState<string[]>([]);
-	const previousLiveContentRef = useRef<string | undefined>(undefined);
 
 	const { action, message, config, onEmitAnalytics, messageParams, openXAppOverlay } =
 		useMessageContext();
@@ -68,18 +67,12 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 		message.text,
 	]);
 
-	useEffect(() => {
-		const data = { textContent, buttonLabels };
-		const liveRegionContent = getLiveRegionContent("textWithButtons", data);
-		if (
-			liveRegionContent &&
-			liveRegionContent !== previousLiveContentRef.current &&
-			buttonLabels.length === buttons.length
-		) {
-			onSetLiveRegionText?.(liveRegionContent);
-			previousLiveContentRef.current = liveRegionContent;
-		}
-	}, [textContent, buttonLabels, onSetLiveRegionText, buttons.length]);
+	useLiveRegion({
+		messageType: "textWithButtons",
+		data: { textContent, buttonLabels },
+		onSetLiveRegionText,
+		validation: () => buttonLabels.length === buttons.length,
+	});
 
 	const stillAnimating =
 		(message as IStreamingMessage).animationState === "animating" ||

--- a/src/messages/TextWithButtons/helper.ts
+++ b/src/messages/TextWithButtons/helper.ts
@@ -1,0 +1,26 @@
+import { sanitizeContent } from "src/sanitize";
+import { getWebchatButtonLabel } from "src/utils";
+
+/**
+ * Get text and buttons in the message, to be used during live region announcement.
+ * @param content - The data containing text and buttons.
+ * @param isSanitizeEnabled - Whether to sanitize HTML content.
+ * @returns An array of objects containing slide text and button labels.
+ */
+export const getTextWithButtonsContent = (
+	content: { text: string; buttons: [] },
+	isSanitizeEnabled: boolean,
+): any => {
+	const { text, buttons } = content;
+	const textContent = sanitizeContent(text, isSanitizeEnabled);
+
+	const buttonLabels =
+		buttons?.map(button => {
+			const buttonLabel = getWebchatButtonLabel(button);
+			const sanitizedButtonLabel = sanitizeContent(buttonLabel, isSanitizeEnabled);
+
+			return sanitizedButtonLabel;
+		}) || [];
+
+	return { textContent, buttonLabels };
+};

--- a/src/messages/Video/Video.tsx
+++ b/src/messages/Video/Video.tsx
@@ -4,7 +4,7 @@ import classes from "./Video.module.css";
 import classnames from "classnames";
 import PrimaryButton from "src/common/Buttons/PrimaryButton";
 import { DownloadIcon, VideoPlayIcon } from "src/assets/svg";
-import { useMessageContext } from "src/messages/hooks";
+import { useLiveRegion, useMessageContext } from "src/messages/hooks";
 import { getChannelPayload } from "src/utils";
 import { IWebchatVideoAttachment } from "@cognigy/socket-client";
 
@@ -19,6 +19,12 @@ const Video: FC = () => {
 
 	const videoPlayerWrapperRef = useRef<HTMLDivElement>(null);
 	const videoPlayerRef = useRef<ReactPlayer>(null);
+
+	useLiveRegion({
+		messageType: "video",
+		data: { hasTranscript: !!altText, hasCaptions: !!captionsUrl },
+		validation: () => !!url,
+	});
 
 	const handleFocus = useCallback(
 		(player: ReactPlayer) => {

--- a/src/messages/context.tsx
+++ b/src/messages/context.tsx
@@ -24,11 +24,13 @@ const MessageContext = createContext<MessageContextValue>(undefined);
  * - messageParams
  * - openXAppOverlay
  * - onSetLiveRegionText
+ * - data-message-id
  */
 const MessageProvider: FC<MessageProviderProps> = props => {
 	const {
 		message,
 		messageParams,
+		"data-message-id": dataMessageId,
 		action,
 		onEmitAnalytics,
 		config,
@@ -43,6 +45,7 @@ const MessageProvider: FC<MessageProviderProps> = props => {
 			onEmitAnalytics,
 			config,
 			messageParams,
+			"data-message-id": dataMessageId,
 			openXAppOverlay,
 			onSetLiveRegionText,
 		}),
@@ -52,6 +55,7 @@ const MessageProvider: FC<MessageProviderProps> = props => {
 			onEmitAnalytics,
 			config,
 			messageParams,
+			dataMessageId,
 			openXAppOverlay,
 			onSetLiveRegionText,
 		],

--- a/src/messages/context.tsx
+++ b/src/messages/context.tsx
@@ -7,7 +7,7 @@ interface MessageProviderProps extends MessageProps {
 		hasReply: MessageProps["hasReply"];
 		isConversationEnded: MessageProps["isConversationEnded"];
 	};
-	headerInfo?: string;
+	headerInfo?: string | null;
 	onSetHeaderInfo?: (headerInfo: string) => void;
 }
 

--- a/src/messages/context.tsx
+++ b/src/messages/context.tsx
@@ -22,13 +22,39 @@ const MessageContext = createContext<MessageContextValue>(undefined);
  * - onEmitAnalytics
  * - config
  * - messageParams
+ * - openXAppOverlay
+ * - onSetLiveRegionText
  */
 const MessageProvider: FC<MessageProviderProps> = props => {
-	const { message, messageParams, action, onEmitAnalytics, config, openXAppOverlay } = props;
+	const {
+		message,
+		messageParams,
+		action,
+		onEmitAnalytics,
+		config,
+		openXAppOverlay,
+		onSetLiveRegionText,
+	} = props;
 
 	const contextValue = useMemo(
-		() => ({ message, action, onEmitAnalytics, config, messageParams, openXAppOverlay }),
-		[message, action, onEmitAnalytics, config, messageParams, openXAppOverlay],
+		() => ({
+			message,
+			action,
+			onEmitAnalytics,
+			config,
+			messageParams,
+			openXAppOverlay,
+			onSetLiveRegionText,
+		}),
+		[
+			message,
+			action,
+			onEmitAnalytics,
+			config,
+			messageParams,
+			openXAppOverlay,
+			onSetLiveRegionText,
+		],
 	);
 
 	return <MessageContext.Provider value={contextValue}>{props.children}</MessageContext.Provider>;

--- a/src/messages/context.tsx
+++ b/src/messages/context.tsx
@@ -7,6 +7,8 @@ interface MessageProviderProps extends MessageProps {
 		hasReply: MessageProps["hasReply"];
 		isConversationEnded: MessageProps["isConversationEnded"];
 	};
+	headerInfo?: string;
+	onSetHeaderInfo?: (headerInfo: string) => void;
 }
 
 export type MessageContextValue = Omit<MessageProviderProps, "children"> | undefined;
@@ -22,6 +24,8 @@ const MessageContext = createContext<MessageContextValue>(undefined);
  * - onEmitAnalytics
  * - config
  * - messageParams
+ * - headerInfo
+ * - onSetHeaderinfo
  * - openXAppOverlay
  * - onSetLiveRegionText
  * - data-message-id
@@ -36,6 +40,8 @@ const MessageProvider: FC<MessageProviderProps> = props => {
 		config,
 		openXAppOverlay,
 		onSetLiveRegionText,
+		headerInfo,
+		onSetHeaderInfo,
 	} = props;
 
 	const contextValue = useMemo(
@@ -48,6 +54,8 @@ const MessageProvider: FC<MessageProviderProps> = props => {
 			"data-message-id": dataMessageId,
 			openXAppOverlay,
 			onSetLiveRegionText,
+			headerInfo,
+			onSetHeaderInfo,
 		}),
 		[
 			message,
@@ -58,6 +66,8 @@ const MessageProvider: FC<MessageProviderProps> = props => {
 			dataMessageId,
 			openXAppOverlay,
 			onSetLiveRegionText,
+			headerInfo,
+			onSetHeaderInfo,
 		],
 	);
 

--- a/src/messages/hooks.ts
+++ b/src/messages/hooks.ts
@@ -46,15 +46,18 @@ const useLiveRegion = ({ messageType, data, validation }: IUseLiveRegionProps) =
 
 		const messageContent = getLiveRegionContent(messageType, data);
 
+		const liveRegionContent =
+			headerInfo !== null ? `${headerInfo} ${messageContent}` : messageContent;
+
 		if (
 			messageContent &&
-			messageContent !== previousLiveContentRef.current &&
+			headerInfo !== "" &&
+			liveRegionContent !== previousLiveContentRef.current &&
 			onSetLiveRegionText &&
 			dataMessageId
 		) {
-			const liveRegionContent = `${headerInfo} ${messageContent}`;
-			onSetLiveRegionText(dataMessageId, liveRegionContent);
-			previousLiveContentRef.current = messageContent;
+			onSetLiveRegionText(dataMessageId, liveRegionContent as string);
+			previousLiveContentRef.current = liveRegionContent;
 		}
 	}, [messageType, data, onSetLiveRegionText, validation, dataMessageId, headerInfo]);
 };

--- a/src/messages/hooks.ts
+++ b/src/messages/hooks.ts
@@ -53,7 +53,6 @@ const useLiveRegion = ({ messageType, data, validation }: IUseLiveRegionProps) =
 			dataMessageId
 		) {
 			const liveRegionContent = `${headerInfo} ${messageContent}`;
-
 			onSetLiveRegionText(dataMessageId, liveRegionContent);
 			previousLiveContentRef.current = messageContent;
 		}

--- a/src/messages/hooks.ts
+++ b/src/messages/hooks.ts
@@ -2,7 +2,7 @@ import { useContext, useState, useEffect, useRef } from "react";
 import { MessageContext } from "./context.tsx";
 import { CollateMessage, getRandomId } from "src/utils.ts";
 import { CollationContext } from "./collation.tsx";
-import { getLiveRegionContent, MessageType } from "src/utils";
+import { getLiveRegionContent, MessageType } from "./live-region-helper.ts";
 
 function useMessageContext() {
 	const state = useContext(MessageContext);

--- a/src/messages/hooks.ts
+++ b/src/messages/hooks.ts
@@ -30,17 +30,12 @@ function useCollation(): CollateMessage | undefined {
 interface IUseLiveRegionProps {
 	messageType: MessageType;
 	data: any;
-	onSetLiveRegionText?: (text: string) => void;
 	validation?: () => boolean;
 }
 
-const useLiveRegion = ({
-	messageType,
-	data,
-	onSetLiveRegionText,
-	validation,
-}: IUseLiveRegionProps) => {
+const useLiveRegion = ({ messageType, data, validation }: IUseLiveRegionProps) => {
 	const previousLiveContentRef = useRef<string | undefined>(undefined);
+	const { onSetLiveRegionText } = useMessageContext();
 
 	useEffect(() => {
 		if (validation && !validation()) return;

--- a/src/messages/hooks.ts
+++ b/src/messages/hooks.ts
@@ -35,7 +35,7 @@ interface IUseLiveRegionProps {
 
 const useLiveRegion = ({ messageType, data, validation }: IUseLiveRegionProps) => {
 	const previousLiveContentRef = useRef<string | undefined>(undefined);
-	const { onSetLiveRegionText } = useMessageContext();
+	const { onSetLiveRegionText, "data-message-id": dataMessageId } = useMessageContext();
 
 	useEffect(() => {
 		if (validation && !validation()) return;
@@ -45,12 +45,13 @@ const useLiveRegion = ({ messageType, data, validation }: IUseLiveRegionProps) =
 		if (
 			liveRegionContent &&
 			liveRegionContent !== previousLiveContentRef.current &&
-			onSetLiveRegionText
+			onSetLiveRegionText &&
+			dataMessageId
 		) {
-			onSetLiveRegionText(liveRegionContent);
+			onSetLiveRegionText(dataMessageId, liveRegionContent);
 			previousLiveContentRef.current = liveRegionContent;
 		}
-	}, [messageType, data, onSetLiveRegionText, validation]);
+	}, [messageType, data, onSetLiveRegionText, validation, dataMessageId]);
 };
 
 export { useMessageContext, useRandomId, useCollation, useLiveRegion };

--- a/src/messages/hooks.ts
+++ b/src/messages/hooks.ts
@@ -35,23 +35,29 @@ interface IUseLiveRegionProps {
 
 const useLiveRegion = ({ messageType, data, validation }: IUseLiveRegionProps) => {
 	const previousLiveContentRef = useRef<string | undefined>(undefined);
-	const { onSetLiveRegionText, "data-message-id": dataMessageId } = useMessageContext();
+	const {
+		onSetLiveRegionText,
+		"data-message-id": dataMessageId,
+		headerInfo,
+	} = useMessageContext();
 
 	useEffect(() => {
 		if (validation && !validation()) return;
 
-		const liveRegionContent = getLiveRegionContent(messageType, data);
+		const messageContent = getLiveRegionContent(messageType, data);
 
 		if (
-			liveRegionContent &&
-			liveRegionContent !== previousLiveContentRef.current &&
+			messageContent &&
+			messageContent !== previousLiveContentRef.current &&
 			onSetLiveRegionText &&
 			dataMessageId
 		) {
+			const liveRegionContent = `${headerInfo} ${messageContent}`;
+
 			onSetLiveRegionText(dataMessageId, liveRegionContent);
-			previousLiveContentRef.current = liveRegionContent;
+			previousLiveContentRef.current = messageContent;
 		}
-	}, [messageType, data, onSetLiveRegionText, validation, dataMessageId]);
+	}, [messageType, data, onSetLiveRegionText, validation, dataMessageId, headerInfo]);
 };
 
 export { useMessageContext, useRandomId, useCollation, useLiveRegion };

--- a/src/messages/live-region-helper.ts
+++ b/src/messages/live-region-helper.ts
@@ -64,7 +64,7 @@ const getTextWithButtonsContent = (data: {
 	const { text, buttons } = data;
 
 	if (text && buttons.length > 0) {
-		return `${text}. Available options: ${buttons.join(", ")}`;
+		return `${text}. Available options: ${formatListWithFullStop(buttons)}`;
 	}
 
 	return text || undefined;
@@ -81,7 +81,7 @@ const getGalleryContent = (data: { slides: any[] }): string | undefined => {
 		const { slideText, buttonLabels } = slides[0];
 		const actionsText =
 			buttonLabels && buttonLabels.length > 0
-				? `Available actions: ${buttonLabels.join(", ")}`
+				? `Available actions: ${formatListWithFullStop(buttonLabels)}`
 				: undefined;
 
 		return slideText && actionsText
@@ -95,7 +95,7 @@ const getGalleryContent = (data: { slides: any[] }): string | undefined => {
 			const { slideText, buttonLabels } = slide;
 			const actionsText =
 				buttonLabels && buttonLabels.length > 0
-					? `Available actions: ${buttonLabels.join(", ")}`
+					? `Available actions: ${formatListWithFullStop(buttonLabels)}`
 					: undefined;
 
 			return slideText && actionsText
@@ -112,10 +112,11 @@ const getGalleryContent = (data: { slides: any[] }): string | undefined => {
 
 const getListContent = (data: any): string | undefined => {
 	const headerLabel = data[0];
-	const itemLabels = Object.keys(data)
+	const items = Object.keys(data)
 		.filter(key => key !== "0")
-		.map(key => data[key])
-		.join(", ");
+		.map(key => data[key]);
+
+	const itemLabels = formatListWithFullStop(items);
 
 	if (headerLabel && itemLabels) {
 		return `${headerLabel}. Available list items: ${itemLabels}`;
@@ -185,4 +186,23 @@ const getEventContent = (data: { dataMessageId: string }): string | undefined =>
 	// Event status pills are ignored from the live region announcement as they have their own aria-live="assertive" attribute.
 	// Webchat will check for the IGNORE- prefix in the liveContent and will skip announcement.
 	return data.dataMessageId ? `IGNORE-${data.dataMessageId}` : undefined;
+};
+
+/**
+ * Formats a list of strings by joining them with commas and adding a full stop to the last item.
+ * @param items The list of strings to format.
+ * @returns A formatted string with a full stop at the end.
+ */
+const formatListWithFullStop = (items: string[]): string => {
+	if (!items || items.length === 0) {
+		return "";
+	}
+
+	if (items.length === 1) {
+		return `${items[0]}.`;
+	}
+
+	const allButLast = items.slice(0, -1).join(", ");
+	const lastItem = items[items.length - 1];
+	return `${allButLast}, and ${lastItem}.`;
 };

--- a/src/messages/live-region-helper.ts
+++ b/src/messages/live-region-helper.ts
@@ -13,54 +13,72 @@ export type MessageType =
 	| "event"
 	| "custom";
 
+type TTextData = { text: string };
+type TTextWithButtonsData = { text: string; buttons: string[] };
+type TGalleryData = { slides: { slideText?: string; buttonLabels?: string[] }[] };
+type TListData = { [key: string]: string };
+type TImageData = { altText: string; isDownloadable: boolean };
+type TVideoData = { hasTranscript: boolean; hasCaptions: boolean };
+type TAudioData = { hasTranscript: boolean };
+type TFileData = { text: string; attachments: IUploadFileAttachmentData[] };
+type TEventData = { dataMessageId: string };
+
+type MessageData =
+	| TTextData
+	| TTextWithButtonsData
+	| TGalleryData
+	| TListData
+	| TImageData
+	| TVideoData
+	| TAudioData
+	| TFileData
+	| TEventData;
+
 /**
  * Computes the live region text based on the message type and provided data.
  * @param messageType The type of the message.
  * @param data The data required to compute the live region text.
  * @returns The computed live region text.
  */
-export const getLiveRegionContent = (messageType: MessageType, data: any): string | undefined => {
+export const getLiveRegionContent = (messageType: MessageType, data: MessageData) => {
 	switch (messageType) {
 		case "text":
-			return getTextContent(data);
+			return getTextContent(data as TTextData);
 
 		case "textWithButtons":
-			return getTextWithButtonsContent(data);
+			return getTextWithButtonsContent(data as TTextWithButtonsData);
 
 		case "gallery":
-			return getGalleryContent(data);
+			return getGalleryContent(data as TGalleryData);
 
 		case "list":
-			return getListContent(data);
+			return getListContent(data as TListData);
 
 		case "image":
-			return getImageContent(data);
+			return getImageContent(data as TImageData);
 
 		case "video":
-			return getVideoContent(data);
+			return getVideoContent(data as TVideoData);
 
 		case "audio":
-			return getAudioContent(data);
+			return getAudioContent(data as TAudioData);
 
 		case "file":
-			return getFileContent(data);
+			return getFileContent(data as TFileData);
 
 		case "event":
-			return getEventContent(data);
+			return getEventContent(data as TEventData);
 
 		default:
 			return undefined;
 	}
 };
 
-const getTextContent = (data: { text: string }): string | undefined => {
+const getTextContent = (data: TTextData) => {
 	return data.text || undefined;
 };
 
-const getTextWithButtonsContent = (data: {
-	text: string;
-	buttons: string[];
-}): string | undefined => {
+const getTextWithButtonsContent = (data: TTextWithButtonsData) => {
 	const { text, buttons } = data;
 
 	if (text && buttons.length > 0) {
@@ -70,7 +88,7 @@ const getTextWithButtonsContent = (data: {
 	return text || undefined;
 };
 
-const getGalleryContent = (data: { slides: any[] }): string | undefined => {
+const getGalleryContent = (data: TGalleryData) => {
 	const { slides } = data;
 
 	if (!slides || slides.length === 0) {
@@ -110,7 +128,7 @@ const getGalleryContent = (data: { slides: any[] }): string | undefined => {
 	return `${slidesCountText} ${slidesContent}`;
 };
 
-const getListContent = (data: any): string | undefined => {
+const getListContent = (data: TListData) => {
 	const headerLabel = data[0];
 	const items = Object.keys(data)
 		.filter(key => key !== "0")
@@ -130,10 +148,7 @@ const getListContent = (data: any): string | undefined => {
 	return undefined;
 };
 
-const getImageContent = (data: {
-	altText: string;
-	isDownloadable: boolean;
-}): string | undefined => {
+const getImageContent = (data: TImageData) => {
 	const { altText, isDownloadable } = data;
 	const altTextLabel = altText ?? "";
 
@@ -142,10 +157,7 @@ const getImageContent = (data: {
 		: `An image. ${altTextLabel}`;
 };
 
-const getVideoContent = (data: {
-	hasTranscript: boolean;
-	hasCaptions: boolean;
-}): string | undefined => {
+const getVideoContent = (data: TVideoData) => {
 	const { hasTranscript, hasCaptions } = data;
 
 	if (hasTranscript && hasCaptions) {
@@ -160,14 +172,11 @@ const getVideoContent = (data: {
 	return "A video message.";
 };
 
-const getAudioContent = (data: { hasTranscript: boolean }): string | undefined => {
+const getAudioContent = (data: TAudioData) => {
 	return data.hasTranscript ? "An audio message with transcript." : "An audio message.";
 };
 
-const getFileContent = (data: {
-	text: string;
-	attachments: IUploadFileAttachmentData[];
-}): string | undefined => {
+const getFileContent = (data: TFileData) => {
 	const { text, attachments } = data;
 
 	if (attachments.length === 1) {
@@ -185,7 +194,7 @@ const getFileContent = (data: {
 		.join(" ")}`;
 };
 
-const getEventContent = (data: { dataMessageId: string }): string | undefined => {
+const getEventContent = (data: TEventData) => {
 	// Event status pills are ignored from the live region announcement as they have their own aria-live="assertive" attribute.
 	// Webchat will check for the IGNORE- prefix in the liveContent and will skip announcement.
 	return data.dataMessageId ? `IGNORE-${data.dataMessageId}` : undefined;

--- a/src/messages/live-region-helper.ts
+++ b/src/messages/live-region-helper.ts
@@ -207,5 +207,5 @@ const formatListWithFullStop = (items: string[]): string => {
 
 	const allButLast = items.slice(0, -1).join(", ");
 	const lastItem = items[items.length - 1];
-	return `${allButLast}, and ${lastItem}.`;
+	return `${allButLast}, ${lastItem}.`;
 };

--- a/src/messages/live-region-helper.ts
+++ b/src/messages/live-region-helper.ts
@@ -1,0 +1,188 @@
+import { IUploadFileAttachmentData } from "@cognigy/socket-client";
+import { getSizeLabel, isImageAttachment } from "./File/helper";
+
+export type MessageType =
+	| "list"
+	| "textWithButtons"
+	| "text"
+	| "gallery"
+	| "image"
+	| "video"
+	| "audio"
+	| "file"
+	| "event"
+	| "custom";
+
+/**
+ * Computes the live region text based on the message type and provided data.
+ * @param messageType The type of the message.
+ * @param data The data required to compute the live region text.
+ * @returns The computed live region text.
+ */
+export const getLiveRegionContent = (messageType: MessageType, data: any): string | undefined => {
+	switch (messageType) {
+		case "text":
+			return getTextContent(data);
+
+		case "textWithButtons":
+			return getTextWithButtonsContent(data);
+
+		case "gallery":
+			return getGalleryContent(data);
+
+		case "list":
+			return getListContent(data);
+
+		case "image":
+			return getImageContent(data);
+
+		case "video":
+			return getVideoContent(data);
+
+		case "audio":
+			return getAudioContent(data);
+
+		case "file":
+			return getFileContent(data);
+
+		case "event":
+			return getEventContent(data);
+
+		default:
+			return undefined;
+	}
+};
+
+const getTextContent = (data: { text: string }): string | undefined => {
+	return data.text || undefined;
+};
+
+const getTextWithButtonsContent = (data: {
+	text: string;
+	buttons: string[];
+}): string | undefined => {
+	const { text, buttons } = data;
+
+	if (text && buttons.length > 0) {
+		return `${text}. Available options: ${buttons.join(", ")}`;
+	}
+
+	return text || undefined;
+};
+
+const getGalleryContent = (data: { slides: any[] }): string | undefined => {
+	const { slides } = data;
+
+	if (!slides || slides.length === 0) {
+		return undefined;
+	}
+
+	if (slides.length === 1) {
+		const { slideText, buttonLabels } = slides[0];
+		const actionsText =
+			buttonLabels && buttonLabels.length > 0
+				? `Available actions: ${buttonLabels.join(", ")}`
+				: undefined;
+
+		return slideText && actionsText
+			? `${slideText}. ${actionsText}`
+			: slideText || actionsText || undefined;
+	}
+
+	const slidesCountText = `${slides.length} slides.`;
+	const slidesContent = slides
+		.map((slide, index) => {
+			const { slideText, buttonLabels } = slide;
+			const actionsText =
+				buttonLabels && buttonLabels.length > 0
+					? `Available actions: ${buttonLabels.join(", ")}`
+					: undefined;
+
+			return slideText && actionsText
+				? `Slide ${index + 1}: ${slideText}. ${actionsText}`
+				: slideText
+					? `Slide ${index + 1}: ${slideText}`
+					: undefined;
+		})
+		.filter(Boolean)
+		.join(" ");
+
+	return `${slidesCountText} ${slidesContent}`;
+};
+
+const getListContent = (data: any): string | undefined => {
+	const headerLabel = data[0];
+	const itemLabels = Object.keys(data)
+		.filter(key => key !== "0")
+		.map(key => data[key])
+		.join(", ");
+
+	if (headerLabel && itemLabels) {
+		return `${headerLabel}. Available list items: ${itemLabels}`;
+	}
+	if (itemLabels) {
+		return `Available list items: ${itemLabels}`;
+	}
+	if (headerLabel) {
+		return headerLabel;
+	}
+	return undefined;
+};
+
+const getImageContent = (data: {
+	altText: string;
+	isDownloadable: boolean;
+}): string | undefined => {
+	const { altText, isDownloadable } = data;
+	const altTextLabel = altText ?? "";
+
+	return isDownloadable
+		? `An image with download option. ${altTextLabel}`
+		: `An image. ${altTextLabel}`;
+};
+
+const getVideoContent = (data: {
+	hasTranscript: boolean;
+	hasCaptions: boolean;
+}): string | undefined => {
+	const { hasTranscript, hasCaptions } = data;
+
+	if (hasTranscript && hasCaptions) {
+		return "A video with transcript and captions.";
+	}
+	if (hasTranscript) {
+		return "A video with transcript.";
+	}
+	if (hasCaptions) {
+		return "A video with captions.";
+	}
+	return "A video message.";
+};
+
+const getAudioContent = (data: { hasTranscript: boolean }): string | undefined => {
+	return data.hasTranscript ? "An audio message with transcript." : "An audio message.";
+};
+
+const getFileContent = (data: { attachments: IUploadFileAttachmentData[] }): string | undefined => {
+	const { attachments } = data;
+
+	if (attachments.length === 1) {
+		const { fileName, size, mimeType } = attachments[0];
+		const sizeLabel = getSizeLabel(size);
+		const type = isImageAttachment(mimeType) ? "image" : "file";
+		return `A ${type} named '${fileName}' with size ${sizeLabel}.`;
+	}
+
+	return `${attachments.length} files. ${attachments
+		.map(
+			(attachment, index) =>
+				`File ${index + 1}: '${attachment.fileName}', size ${getSizeLabel(attachment.size)}.`,
+		)
+		.join(" ")}`;
+};
+
+const getEventContent = (data: { dataMessageId: string }): string | undefined => {
+	// Event status pills are ignored from the live region announcement as they have their own aria-live="assertive" attribute.
+	// Webchat will check for the IGNORE- prefix in the liveContent and will skip announcement.
+	return data.dataMessageId ? `IGNORE-${data.dataMessageId}` : undefined;
+};

--- a/src/messages/live-region-helper.ts
+++ b/src/messages/live-region-helper.ts
@@ -164,17 +164,20 @@ const getAudioContent = (data: { hasTranscript: boolean }): string | undefined =
 	return data.hasTranscript ? "An audio message with transcript." : "An audio message.";
 };
 
-const getFileContent = (data: { attachments: IUploadFileAttachmentData[] }): string | undefined => {
-	const { attachments } = data;
+const getFileContent = (data: {
+	text: string;
+	attachments: IUploadFileAttachmentData[];
+}): string | undefined => {
+	const { text, attachments } = data;
 
 	if (attachments.length === 1) {
 		const { fileName, size, mimeType } = attachments[0];
 		const sizeLabel = getSizeLabel(size);
 		const type = isImageAttachment(mimeType) ? "image" : "file";
-		return `A ${type} named '${fileName}' with size ${sizeLabel}.`;
+		return `${text}. A ${type} named '${fileName}' with size ${sizeLabel}.`;
 	}
 
-	return `${attachments.length} files. ${attachments
+	return `${text}. ${attachments.length} files. ${attachments
 		.map(
 			(attachment, index) =>
 				`File ${index + 1}: '${attachment.fileName}', size ${getSizeLabel(attachment.size)}.`,

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -244,3 +244,19 @@ export const sanitizeHTML = (text: string) => {
 	DOMPurify.removeAllHooks();
 	return result;
 };
+
+/**
+ * Sanitizes content if sanitization is enabled.
+ * @param content - The content to sanitize.
+ * @param isSanitizeEnabled - Whether to sanitize the content.
+ * @returns The sanitized or raw content.
+ */
+export const sanitizeContent = (
+	content: string | undefined,
+	isSanitizeEnabled: boolean,
+): string => {
+	if (!content) {
+		return "";
+	}
+	return isSanitizeEnabled ? sanitizeHTML(content) : content;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,16 +170,33 @@ export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	return enhancedText;
 };
 
-export type MessageType = "list" | "textWithButtons";
+export type MessageType =
+	| "list"
+	| "textWithButtons"
+	| "text"
+	| "image"
+	| "video"
+	| "audio"
+	| "file"
+	| "custom";
 
 /**
  * Computes the live region text based on the message type and provided data.
- * @param messageType The type of the message (e.g., "list", "textWithButtons").
+ * @param messageType The type of the message.
  * @param data The data required to compute the live region text.
  * @returns The computed live region text.
  */
 export const getLiveRegionContent = (messageType: MessageType, data: any): string | undefined => {
 	switch (messageType) {
+		case "text": {
+			const { text } = data;
+
+			if (text) {
+				return text;
+			}
+			return undefined;
+		}
+
 		case "textWithButtons": {
 			const { textContent, buttonLabels } = data;
 
@@ -207,6 +224,42 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 				return headerLabel;
 			}
 			return undefined;
+		}
+
+		case "image": {
+			const { altText, isDownloadable } = data;
+			const altTextLabel = altText ?? "";
+
+			if (isDownloadable) {
+				return `An image with download option. ${altTextLabel}`;
+			} else {
+				return `A new image. ${altTextLabel}`;
+			}
+		}
+
+		case "video": {
+			const { hasTranscript, hasCaptions } = data;
+
+			if (hasTranscript && hasCaptions) {
+				return "A video with transcript and captions.";
+			}
+			if (hasTranscript) {
+				return "A video with transcript.";
+			}
+			if (hasCaptions) {
+				return "A video with captions.";
+			}
+			return "A new video.";
+		}
+
+		case "audio": {
+			const { hasTrascript } = data;
+
+			if (hasTrascript) {
+				return "An audio message with transcript.";
+			}
+
+			return "A new audio.";
 		}
 
 		default:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,3 +169,46 @@ export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 
 	return enhancedText;
 };
+
+export type MessageType = "list" | "textWithButtons";
+
+/**
+ * Computes the live region text based on the message type and provided data.
+ * @param messageType The type of the message (e.g., "list", "textWithButtons").
+ * @param data The data required to compute the live region text.
+ * @returns The computed live region text.
+ */
+export const getLiveRegionContent = (messageType: MessageType, data: any): string | undefined => {
+	switch (messageType) {
+		case "textWithButtons": {
+			const { textContent, buttonLabels } = data;
+
+			if (!!textContent && buttonLabels.length > 0) {
+				return `${textContent}${" Available options: " + buttonLabels.join(", ")}`;
+			}
+			return undefined;
+		}
+
+		case "list": {
+			const headerLabel = data[0];
+
+			const itemLabels = Object.keys(data)
+				.filter(key => key !== "0")
+				.map(key => data[key])
+				.join(", ");
+			if (headerLabel && itemLabels) {
+				return `${headerLabel}. Available list items: ${itemLabels}`;
+			}
+			if (itemLabels) {
+				return `Available list items: ${itemLabels}`;
+			}
+			if (headerLabel) {
+				return headerLabel;
+			}
+			return undefined;
+		}
+
+		default:
+			return undefined;
+	}
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -212,6 +212,8 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 		default:
 			return undefined;
 	}
+};
+
 /**
  * Utility function to get focusable elements and find the next or previous focusable element relative to the currently focused element.
  * @param element The container element to search for focusable elements.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,7 @@
-import { IMessage, IUploadFileAttachmentData, IWebchatMessage } from "@cognigy/socket-client";
+import { IMessage, IWebchatMessage } from "@cognigy/socket-client";
 import { IWebchatConfig } from "./messages/types";
 import { ActionButtonsProps } from "./common/ActionButtons/ActionButtons";
 import { match, MessagePlugin } from "./matcher";
-import { getSizeLabel, isImageAttachment } from "./messages/File/helper";
 
 /**
  * Decides between _webchat and _facebook payload.
@@ -169,131 +168,6 @@ export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 	});
 
 	return enhancedText;
-};
-
-export type MessageType =
-	| "list"
-	| "textWithButtons"
-	| "text"
-	| "image"
-	| "video"
-	| "audio"
-	| "file"
-	| "event"
-	| "custom";
-
-/**
- * Computes the live region text based on the message type and provided data.
- * @param messageType The type of the message.
- * @param data The data required to compute the live region text.
- * @returns The computed live region text.
- */
-export const getLiveRegionContent = (messageType: MessageType, data: any): string | undefined => {
-	switch (messageType) {
-		case "text": {
-			const { text } = data;
-
-			if (text) {
-				return text;
-			}
-			return undefined;
-		}
-
-		case "textWithButtons": {
-			const { text, buttons } = data;
-
-			if (!!text && buttons.length > 0) {
-				return `${text}${" Available options: " + buttons.join(", ")}`;
-			}
-			return undefined;
-		}
-
-		case "list": {
-			const headerLabel = data[0];
-
-			const itemLabels = Object.keys(data)
-				.filter(key => key !== "0")
-				.map(key => data[key])
-				.join(", ");
-
-			if (headerLabel && itemLabels) {
-				return `${headerLabel}. Available list items: ${itemLabels}`;
-			}
-			if (itemLabels) {
-				return `Available list items: ${itemLabels}`;
-			}
-			if (headerLabel) {
-				return headerLabel;
-			}
-			return undefined;
-		}
-
-		case "image": {
-			const { altText, isDownloadable } = data;
-			const altTextLabel = altText ?? "";
-
-			if (isDownloadable) {
-				return `An image with download option. ${altTextLabel}`;
-			} else {
-				return `An image. ${altTextLabel}`;
-			}
-		}
-
-		case "video": {
-			const { hasTranscript, hasCaptions } = data;
-
-			if (hasTranscript && hasCaptions) {
-				return "A video with transcript and captions.";
-			}
-			if (hasTranscript) {
-				return "A video with transcript.";
-			}
-			if (hasCaptions) {
-				return "A video with captions.";
-			}
-			return "A video message.";
-		}
-
-		case "audio": {
-			const { hasTrascript } = data;
-
-			if (hasTrascript) {
-				return "An audio message with transcript.";
-			}
-
-			return "An audio message.";
-		}
-
-		case "file": {
-			const { attachments } = data;
-
-			if (attachments.length === 1) {
-				const { fileName, size, mimeType } = attachments[0] as IUploadFileAttachmentData;
-				const sizeLabel = getSizeLabel(size);
-				const type = isImageAttachment(mimeType) ? "image" : "file";
-				return `A ${type} named '${fileName}' with size ${sizeLabel}.`;
-			}
-
-			return `${attachments.length} files have been received. ${attachments
-				.map(
-					(attachment: IUploadFileAttachmentData, index: number) =>
-						`File ${index + 1}: '${attachment.fileName}', size ${getSizeLabel(attachment.size)}.`,
-				)
-				.join(" ")}`;
-		}
-
-		// Event status pills are ignore from the live region as they have their own aria-live="assertive" attribute
-		case "event": {
-			const { dataMessageId } = data;
-			if (dataMessageId) {
-				return `IGNORE-${dataMessageId}`;
-			}
-			return undefined;
-		}
-
-		default:
-			return undefined;
-	}
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -200,10 +200,10 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 		}
 
 		case "textWithButtons": {
-			const { textContent, buttonLabels } = data;
+			const { text, buttons } = data;
 
-			if (!!textContent && buttonLabels.length > 0) {
-				return `${textContent}${" Available options: " + buttonLabels.join(", ")}`;
+			if (!!text && buttons.length > 0) {
+				return `${text}${" Available options: " + buttons.join(", ")}`;
 			}
 			return undefined;
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -235,7 +235,7 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 			if (isDownloadable) {
 				return `An image with download option. ${altTextLabel}`;
 			} else {
-				return `A new image. ${altTextLabel}`;
+				return `An image. ${altTextLabel}`;
 			}
 		}
 
@@ -251,7 +251,7 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 			if (hasCaptions) {
 				return "A video with captions.";
 			}
-			return "A new video.";
+			return "A video message.";
 		}
 
 		case "audio": {
@@ -261,7 +261,7 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 				return "An audio message with transcript.";
 			}
 
-			return "A new audio.";
+			return "An audio message.";
 		}
 
 		case "file": {
@@ -271,10 +271,10 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 				const { fileName, size, mimeType } = attachments[0] as IUploadFileAttachmentData;
 				const sizeLabel = getSizeLabel(size);
 				const type = isImageAttachment(mimeType) ? "image" : "file";
-				return `A new ${type} named '${fileName}' with size ${sizeLabel}.`;
+				return `A ${type} named '${fileName}' with size ${sizeLabel}.`;
 			}
 
-			return `${attachments.length} new files have been received. ${attachments
+			return `${attachments.length} files have been received. ${attachments
 				.map(
 					(attachment: IUploadFileAttachmentData, index: number) =>
 						`File ${index + 1}: '${attachment.fileName}', size ${getSizeLabel(attachment.size)}.`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,6 +179,7 @@ export type MessageType =
 	| "video"
 	| "audio"
 	| "file"
+	| "event"
 	| "custom";
 
 /**
@@ -279,6 +280,15 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 						`File ${index + 1}: '${attachment.fileName}', size ${getSizeLabel(attachment.size)}.`,
 				)
 				.join(" ")}`;
+		}
+
+		// Event status pills are ignore from the live region as they have their own aria-live="assertive" attribute
+		case "event": {
+			const { dataMessageId } = data;
+			if (dataMessageId) {
+				return `IGNORE-${dataMessageId}`;
+			}
+			return undefined;
 		}
 
 		default:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
-import { IMessage, IWebchatMessage } from "@cognigy/socket-client";
+import { IMessage, IUploadFileAttachmentData, IWebchatMessage } from "@cognigy/socket-client";
 import { IWebchatConfig } from "./messages/types";
 import { ActionButtonsProps } from "./common/ActionButtons/ActionButtons";
 import { match, MessagePlugin } from "./matcher";
+import { getSizeLabel, isImageAttachment } from "./messages/File/helper";
 
 /**
  * Decides between _webchat and _facebook payload.
@@ -260,6 +261,24 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 			}
 
 			return "A new audio.";
+		}
+
+		case "file": {
+			const { attachments } = data;
+
+			if (attachments.length === 1) {
+				const { fileName, size, mimeType } = attachments[0] as IUploadFileAttachmentData;
+				const sizeLabel = getSizeLabel(size);
+				const type = isImageAttachment(mimeType) ? "image" : "file";
+				return `A new ${type} named '${fileName}' with size ${sizeLabel}.`;
+			}
+
+			return `${attachments.length} new files have been received. ${attachments
+				.map(
+					(attachment: IUploadFileAttachmentData, index: number) =>
+						`File ${index + 1}: '${attachment.fileName}', size ${getSizeLabel(attachment.size)}.`,
+				)
+				.join(" ")}`;
 		}
 
 		default:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -196,6 +196,7 @@ export const getLiveRegionContent = (messageType: MessageType, data: any): strin
 				.filter(key => key !== "0")
 				.map(key => data[key])
 				.join(", ");
+
 			if (headerLabel && itemLabels) {
 				return `${headerLabel}. Available list items: ${itemLabels}`;
 			}

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -20,7 +20,7 @@ describe("Action Buttons", () => {
 			render(<Message message={message} />);
 		});
 
-		expect(screen.getByRole("group")).toBeInTheDocument();
+		expect(screen.getByRole("list")).toBeInTheDocument();
 		expect(screen.getAllByRole("button", { name: /foobar005b(1|2|3|4)/ })).toHaveLength(2);
 		expect(screen.getAllByRole("link", { name: /foobar005b(1|2|3|4)/ })).toHaveLength(2);
 	});
@@ -30,7 +30,7 @@ describe("Action Buttons", () => {
 			render(<Message message={message} />);
 		});
 
-		expect(screen.getAllByLabelText(/Item (1|2|3|4) of 4: foobar005b(1|2|3|4)/)).toHaveLength(
+		expect(screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/)).toHaveLength(
 			4,
 		);
 	});
@@ -40,7 +40,7 @@ describe("Action Buttons", () => {
 			render(<Message message={message} />);
 		});
 
-		const phoneButton = screen.getByLabelText(/Item 4 of 4: foobar005b4/);
+		const phoneButton = screen.getByLabelText(/4 of 4: foobar005b4/);
 		expect(phoneButton).toHaveAttribute("href", "tel:000111222");
 	});
 

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -30,9 +30,7 @@ describe("Action Buttons", () => {
 			render(<Message message={message} />);
 		});
 
-		expect(screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/)).toHaveLength(
-			4,
-		);
+		expect(screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/)).toHaveLength(4);
 	});
 
 	it("renders phone number button as anchor element with 'href' attribute", async () => {

--- a/test/Gallery.spec.tsx
+++ b/test/Gallery.spec.tsx
@@ -16,7 +16,7 @@ describe("Message Gallery", () => {
 	it("renders images inside gallery", () => {
 		const { getAllByAltText } = render(<Message message={message} />);
 
-		expect(getAllByAltText("Attachment Image")).toHaveLength(8);
+		expect(getAllByAltText("foobar004g1")).toHaveLength(8);
 	});
 
 	it("renders subtitles", () => {

--- a/test/List.spec.tsx
+++ b/test/List.spec.tsx
@@ -62,6 +62,6 @@ describe("Message List", () => {
 		const { getByRole, getAllByRole } = render(<Message message={message} />);
 
 		expect(getByRole("list")).toBeInTheDocument();
-		expect(getAllByRole("listitem")).toHaveLength(5);
+		expect(getAllByRole("listitem")).toHaveLength(4); // Header element is not a list item
 	});
 });

--- a/test/fixtures/gallery.json
+++ b/test/fixtures/gallery.json
@@ -10,6 +10,7 @@
 							"title": "foobar004g1",
 							"subtitle": "",
 							"imageUrl": "https://placewaifu.com/image/300/300",
+							"imageAltText": "foobar004g1",
 							"buttons": [
 								{
 									"id": 0.9601740794827666,
@@ -24,6 +25,7 @@
 							"title": "foobar004g2",
 							"subtitle": "foobar004g2sub1\nfoobar004g2sub2",
 							"imageUrl": "https://placewaifu.com/image/300/300",
+							"imageAltText": "foobar004g1",
 							"buttons": [],
 							"id": 0.9969017542005371
 						},
@@ -31,6 +33,7 @@
 							"title": "foobar004g3",
 							"subtitle": "",
 							"imageUrl": "",
+							"imageAltText": "",
 							"buttons": [],
 							"id": 0.2782939283042508
 						}
@@ -47,6 +50,7 @@
 								{
 									"title": "Cat 1",
 									"image_url": "https://placewaifu.com/image/300/300",
+									"image_alt_text": "foobar004g1",
 									"buttons": [
 										{
 											"type": "postback",
@@ -64,12 +68,14 @@
 									"title": "Cat 2",
 									"subtitle": "foobar004g2sub1\nfoobar004g2sub2",
 									"image_url": "https://placewaifu.com/image/300/300",
+									"image_alt_text": "foobar004g1",
 									"buttons": []
 								},
 								{
 									"title": "Cat 3",
 									"subtitle": "",
 									"image_url": "https://placewaifu.com/image/300/300",
+									"image_alt_text": "foobar004g1",
 									"buttons": [
 										{
 											"type": "postback",
@@ -82,12 +88,14 @@
 									"title": "Cat 4",
 									"subtitle": "foobar004g2sub1\nfoobar004g2sub2",
 									"image_url": "https://placewaifu.com/image/300/300",
+									"image_alt_text": "foobar004g1",
 									"buttons": []
 								},
 								{
 									"title": "Cat 5",
 									"subtitle": "",
 									"image_url": "https://placewaifu.com/image/300/300",
+									"image_alt_text": "foobar004g1",
 									"buttons": [
 										{
 											"type": "postback",
@@ -105,17 +113,20 @@
 									"title": "Cat 6",
 									"subtitle": "foobar004g2sub1\nfoobar004g2sub2",
 									"image_url": "https://placewaifu.com/image/300/300",
+									"image_alt_text": "foobar004g1",
 									"buttons": []
 								},
 								{
 									"title": "Cat 7",
 									"subtitle": "",
 									"image_url": "https://placewaifu.com/image/300/300",
+									"image_alt_text": "foobar004g1",
 									"buttons": null
 								},
 								{
 									"title": "Cat 8",
-									"image_url": "https://placewaifu.com/image/300/300"
+									"image_url": "https://placewaifu.com/image/300/300",
+									"image_alt_text": "foobar004g1"
 								}
 							]
 						}


### PR DESCRIPTION
This PR improves the live announcement of new messages by handling the live message content for each message type.

- Each message type (except xapp, datepicker, adaptivecard) sets a meaningful content to be announced in the live region
- Chat Event pills have aria-live="assertive", so that they are announced immediately
- Timestamp is ignored in the live announcement
- Aria-live=polite is removed from react-swiper-wrapper to avoid double announcement
- Fallback alt is empty string "" when no alt text for an image is provided
- When there is a header element in a list, it is not included as a list-item
- Action buttons now use ul, li tags instead of just role="group"
- Heading levels of gallery and list titles are adjusted

Please pack the chat-components and test it together with https://github.com/Cognigy/Webchat/pull/107