### PR TITLE
Bug/95456 chat event context usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.50.0",
+	"version": "0.51.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.50.0",
+			"version": "0.51.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.50.0",
+	"version": "0.51.0",
 	"type": "module",
 	"main": "./dist/chat-components.js",
 	"exports": {

--- a/src/common/ChatEvent.tsx
+++ b/src/common/ChatEvent.tsx
@@ -2,17 +2,17 @@ import { FC } from "react";
 import classes from "./ChatEvent.module.css";
 import classnames from "classnames";
 import Typography from "./Typography/Typography";
-import { useLiveRegion, useMessageContext } from "src/messages/hooks";
+import { useLiveRegion } from "src/messages/hooks";
 
 export interface ChatEventProps {
 	text?: string;
 	className?: string;
 	id?: string;
+	dataMessageId?: string;
 }
 
 const ChatEvent: FC<ChatEventProps> = props => {
-	const { text, className, id } = props;
-	const { "data-message-id": dataMessageId } = useMessageContext();
+	const { text, className, id, dataMessageId } = props;
 
 	useLiveRegion({
 		messageType: "event",

--- a/src/common/ChatEvent.tsx
+++ b/src/common/ChatEvent.tsx
@@ -2,22 +2,15 @@ import { FC } from "react";
 import classes from "./ChatEvent.module.css";
 import classnames from "classnames";
 import Typography from "./Typography/Typography";
-import { useLiveRegion } from "src/messages/hooks";
 
 export interface ChatEventProps {
 	text?: string;
 	className?: string;
 	id?: string;
-	dataMessageId?: string;
 }
 
 const ChatEvent: FC<ChatEventProps> = props => {
-	const { text, className, id, dataMessageId } = props;
-
-	useLiveRegion({
-		messageType: "event",
-		data: { dataMessageId },
-	});
+	const { text, className, id } = props;
 
 	return (
 		<div className={classnames(classes.eventPill, className)} id={id} aria-live="assertive">

--- a/src/messages/Webchat3Event.tsx
+++ b/src/messages/Webchat3Event.tsx
@@ -3,14 +3,14 @@ import { useMessageContext } from "src/messages/hooks";
 import ChatEvent from "src/common/ChatEvent";
 
 const Webchat3Event: FC = () => {
-	const { message } = useMessageContext();
+	const { message, "data-message-id": dataMessageId } = useMessageContext();
 
 	if (message?.data?._cognigy?._webchat3?.type !== "liveAgentEvent") return null;
 
 	const text = message?.data?._cognigy?._webchat3?.payload?.text;
 	if (!text) return null;
 
-	return <ChatEvent text={text} />;
+	return <ChatEvent text={text} dataMessageId={dataMessageId} />;
 };
 
 export default Webchat3Event;

--- a/src/messages/Webchat3Event.tsx
+++ b/src/messages/Webchat3Event.tsx
@@ -1,16 +1,22 @@
 import { FC } from "react";
-import { useMessageContext } from "src/messages/hooks";
+import { useLiveRegion, useMessageContext } from "src/messages/hooks";
 import ChatEvent from "src/common/ChatEvent";
 
 const Webchat3Event: FC = () => {
 	const { message, "data-message-id": dataMessageId } = useMessageContext();
+
+	useLiveRegion({
+		messageType: "event",
+		data: { dataMessageId },
+		validation: () => !!dataMessageId,
+	});
 
 	if (message?.data?._cognigy?._webchat3?.type !== "liveAgentEvent") return null;
 
 	const text = message?.data?._cognigy?._webchat3?.payload?.text;
 	if (!text) return null;
 
-	return <ChatEvent text={text} dataMessageId={dataMessageId} />;
+	return <ChatEvent text={text} />;
 };
 
 export default Webchat3Event;

--- a/src/messages/xApp/XAppSubmitMessage.tsx
+++ b/src/messages/xApp/XAppSubmitMessage.tsx
@@ -1,5 +1,5 @@
 import { ChatEvent } from "src/index";
-import { useMessageContext } from "../hooks";
+import { useLiveRegion, useMessageContext } from "../hooks";
 
 import type { IPluginXAppSubmit } from "@cognigy/socket-client/lib/interfaces/messageData";
 
@@ -9,7 +9,13 @@ const XAppSubmitMessage = () => {
 	// TODO remove any after socket-client update
 	const { success, text } = (message?.data?._plugin as IPluginXAppSubmit as any)?.data || {};
 
-	return <ChatEvent text={success ? text : "Submission failed"} dataMessageId={dataMessageId} />;
+	useLiveRegion({
+		messageType: "event",
+		data: { dataMessageId },
+		validation: () => !!dataMessageId,
+	});
+
+	return <ChatEvent text={success ? text : "Submission failed"} />;
 };
 
 export default XAppSubmitMessage;

--- a/src/messages/xApp/XAppSubmitMessage.tsx
+++ b/src/messages/xApp/XAppSubmitMessage.tsx
@@ -4,12 +4,12 @@ import { useMessageContext } from "../hooks";
 import type { IPluginXAppSubmit } from "@cognigy/socket-client/lib/interfaces/messageData";
 
 const XAppSubmitMessage = () => {
-	const { message } = useMessageContext();
+	const { message, "data-message-id": dataMessageId } = useMessageContext();
 
 	// TODO remove any after socket-client update
 	const { success, text } = (message?.data?._plugin as IPluginXAppSubmit as any)?.data || {};
 
-	return <ChatEvent text={success ? text : "Submission failed"} />;
+	return <ChatEvent text={success ? text : "Submission failed"} dataMessageId={dataMessageId} />;
 };
 
 export default XAppSubmitMessage;


### PR DESCRIPTION
This PR fixes a regression caused by #128. ChatEvent component can be called both inside and outside of the MessageProvider context. So, usage of useMessageContext hook in ChatEvent will cause an issue, if the component is called outside of the context, for example directly in Webchat repo. 

The issue was identified by the failing test in https://github.com/Cognigy/Webchat/pull/107