### PR TITLE
Feature/101506 improve adaptive card live announcement

### DIFF
--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -90,7 +90,7 @@ const Text: FC<TextProps> = props => {
 					{displayedText}
 				</Markdown>
 			) : (
-				<div
+				<p
 					id={props.id}
 					className={classNames(classes.text, props?.className)}
 					dangerouslySetInnerHTML={{ __html }}

--- a/src/messages/live-region-helper.ts
+++ b/src/messages/live-region-helper.ts
@@ -13,6 +13,7 @@ export type MessageType =
 	| "audio"
 	| "file"
 	| "event"
+	| "adaptiveCard"
 	| "custom";
 
 type TTextData = { text: string };
@@ -24,6 +25,7 @@ type TVideoData = { hasTranscript: boolean; hasCaptions: boolean };
 type TAudioData = { hasTranscript: boolean };
 type TFileData = { text: string; attachments: IUploadFileAttachmentData[] };
 type TEventData = { dataMessageId: string };
+type TAdaptiveCardData = { speakText: string };
 
 type MessageData =
 	| TTextData
@@ -34,6 +36,7 @@ type MessageData =
 	| TVideoData
 	| TAudioData
 	| TFileData
+	| TAdaptiveCardData
 	| TEventData;
 
 /**
@@ -74,6 +77,9 @@ export const getLiveRegionContent = (
 
 		case "event":
 			return getEventContent(data as TEventData);
+
+		case "adaptiveCard":
+			return getAdaptiveCardContent(data as TAdaptiveCardData);
 
 		default:
 			return undefined;
@@ -259,6 +265,10 @@ const getEventContent = (data: TEventData) => {
 	// Event status pills are ignored from the live region announcement as they have their own aria-live="assertive" attribute.
 	// Webchat will check for the IGNORE- prefix in the liveContent and will skip announcement.
 	return data.dataMessageId ? `IGNORE-${data.dataMessageId}` : undefined;
+};
+
+const getAdaptiveCardContent = (data: TAdaptiveCardData) => {
+	return data.speakText || undefined;
 };
 
 /**

--- a/test/fixtures/adaptiveCards.json
+++ b/test/fixtures/adaptiveCards.json
@@ -7,6 +7,7 @@
 					"type": "adaptiveCard",
 					"adaptiveCard": {
 						"type": "AdaptiveCard",
+						"speak": "Information about a kitten visitor and some actions you can take.",
 						"body": [
 							{
 								"type": "TextBlock",


### PR DESCRIPTION
This PR improves the screen-reader announcement of adaptive cards, by using the text provided to the speak prop for live region announcements.

Success Criteria:
- When a speak prop is provided for adaptive card JSON, this is used when making screen-reader announcement upon the arrival of that message
- When speak prop is not provided, the Adaptive card will be read line-by-line.
- Additional change: Replaced div tag with p tag in text bubbles for better screen-reader readability, as mentioned in issue ticket: 100860

How to test:
- Pack the chat-components and test it with webchat
- Create a flow with adaptive card and add a speak prop with some text. Alternatively, you can use this endpoint: https://endpoint-dev.cognigy.ai/590e22c8b3f230b5d35484c0490a119a20e18e8a91f9b652042b89b181b1cef7
- Using a screen reader, check if the text added to the speak prop is announced when the adaptive card message arrives. Also, check if the speak text is read when the adaptive card is focused using keyboard.