### PR TITLE
Remove context usage in ActionButton and pass data-message-id as prop

### DIFF
--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -7,7 +7,6 @@ import { sanitizeUrl } from "@braintree/sanitize-url";
 import classes from "./ActionButton.module.css";
 import { LinkIcon } from "src/assets/svg";
 import { MessageProps, Typography } from "src/index";
-import { useMessageContext } from "src/messages/hooks";
 
 interface ActionButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
 	action?: ActionButtonsProps["action"];
@@ -19,6 +18,7 @@ interface ActionButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
 	customIcon?: ReactElement;
 	showUrlIcon?: boolean;
 	config: MessageProps["config"];
+	dataMessageId?: string;
 	onEmitAnalytics: MessageProps["onEmitAnalytics"];
 	size?: "small" | "large";
 	openXAppOverlay?: (url: string | undefined) => void;
@@ -39,8 +39,8 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		onEmitAnalytics,
 		size,
 		openXAppOverlay,
+		dataMessageId,
 	} = props;
-	const { "data-message-id": dataMessageId } = useMessageContext();
 
 	const buttonType =
 		"type" in button

--- a/src/common/ActionButtons/ActionButtons.tsx
+++ b/src/common/ActionButtons/ActionButtons.tsx
@@ -21,6 +21,7 @@ export interface ActionButtonsProps {
 	customIcon?: ReactElement;
 	showUrlIcon?: boolean;
 	config: MessageProps["config"];
+	dataMessageId?: string;
 	onEmitAnalytics: MessageProps["onEmitAnalytics"];
 	size?: "small" | "large";
 	templateTextId?: string;
@@ -42,6 +43,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 		onEmitAnalytics,
 		size,
 		templateTextId,
+		dataMessageId,
 		openXAppOverlay,
 	} = props;
 
@@ -79,6 +81,7 @@ export const ActionButtons: FC<ActionButtonsProps> = props => {
 		const actionButton = (
 			<ActionButton
 				className={buttonClassName}
+				dataMessageId={dataMessageId}
 				button={button}
 				action={action}
 				disabled={action === undefined}

--- a/src/common/Buttons/PrimaryButton.tsx
+++ b/src/common/Buttons/PrimaryButton.tsx
@@ -13,6 +13,7 @@ interface PrimaryButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	containerClassName?: string;
 	customIcon?: ReactElement;
 	config?: ActionButtonsProps["config"];
+	dataMessageId?: string;
 	onEmitAnalytics?: ActionButtonsProps["onEmitAnalytics"];
 }
 
@@ -25,6 +26,7 @@ const PrimaryButton = forwardRef<HTMLButtonElement, PrimaryButtonProps>((props, 
 		action,
 		isActionButton,
 		config,
+		dataMessageId,
 		onEmitAnalytics,
 		...restProps
 	} = props;
@@ -50,6 +52,7 @@ const PrimaryButton = forwardRef<HTMLButtonElement, PrimaryButtonProps>((props, 
 				classes.actionButton,
 				buttonClassName,
 			)}
+			dataMessageId={dataMessageId}
 			payload={[button]}
 			action={action}
 			customIcon={customIcon}

--- a/src/common/Buttons/SecondaryButton.tsx
+++ b/src/common/Buttons/SecondaryButton.tsx
@@ -13,6 +13,7 @@ interface SecondaryButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	containerClassName?: string;
 	customIcon?: ReactElement;
 	config?: ActionButtonsProps["config"];
+	dataMessageId?: string;
 	onEmitAnalytics?: ActionButtonsProps["onEmitAnalytics"];
 }
 
@@ -25,6 +26,7 @@ const SecondaryButton = forwardRef<HTMLButtonElement, SecondaryButtonProps>((pro
 		action,
 		isActionButton,
 		config,
+		dataMessageId,
 		onEmitAnalytics,
 		...restProps
 	} = props;
@@ -49,6 +51,7 @@ const SecondaryButton = forwardRef<HTMLButtonElement, SecondaryButtonProps>((pro
 				classes.actionButton,
 				buttonClassName,
 			)}
+			dataMessageId={dataMessageId}
 			payload={[button]}
 			action={action}
 			customIcon={customIcon}

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -17,7 +17,13 @@ export interface GallerySlideProps {
 const GalleryItem: FC<GallerySlideProps> = props => {
 	const { slide, contentId } = props;
 	const { title, subtitle, image_url, image_alt_text, buttons, default_action } = slide;
-	const { action, config, onEmitAnalytics, messageParams } = useMessageContext();
+	const {
+		action,
+		config,
+		onEmitAnalytics,
+		messageParams,
+		"data-message-id": dataMessageId,
+	} = useMessageContext();
 	const hasExtraInfo = subtitle || (buttons && buttons?.length > 0);
 	const [isImageBroken, setImageBroken] = useState(false);
 
@@ -94,6 +100,7 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 					)}
 					{buttons && buttons?.length > 0 && (
 						<ActionButtons
+							dataMessageId={dataMessageId}
 							buttonClassName={classnames(
 								buttonClasses.primaryButton,
 								buttonClasses.actionButton,

--- a/src/messages/List/List.tsx
+++ b/src/messages/List/List.tsx
@@ -9,7 +9,14 @@ import { getChannelPayload } from "src/utils";
 import { IWebchatAttachmentElement, IWebchatTemplateAttachment } from "@cognigy/socket-client";
 
 const List: FC = () => {
-	const { message, messageParams, config, action, onEmitAnalytics } = useMessageContext();
+	const {
+		message,
+		messageParams,
+		config,
+		"data-message-id": dataMessageId,
+		action,
+		onEmitAnalytics,
+	} = useMessageContext();
 	const payload = getChannelPayload(message, config);
 
 	const [listItemLiveRegionLabels, setListItemLiveRegionLabels] = useState<
@@ -104,6 +111,7 @@ const List: FC = () => {
 			{button && (
 				<PrimaryButton
 					isActionButton
+					dataMessageId={dataMessageId}
 					action={shouldBeDisabled ? undefined : action}
 					button={button}
 					buttonClassName="webchat-list-template-global-button"

--- a/src/messages/List/ListItem.tsx
+++ b/src/messages/List/ListItem.tsx
@@ -18,7 +18,7 @@ interface IListItemProps {
 }
 
 const ListItem: FC<IListItemProps> = props => {
-	const { action, config, onEmitAnalytics, messageParams } = useMessageContext();
+	const { action, config, onEmitAnalytics, messageParams, "data-message-id": dataMessageId } = useMessageContext();
 	const { element, isHeaderElement, headingLevel, id, onSetScreenReaderLabel } = props;
 	const { title, subtitle, image_url, image_alt_text, default_action, buttons } = element;
 	const button = buttons && buttons?.[0];
@@ -163,6 +163,7 @@ const ListItem: FC<IListItemProps> = props => {
 			{isHeaderElement ? (
 				<PrimaryButton
 					isActionButton
+					dataMessageId={dataMessageId}
 					action={shouldBeDisabled ? undefined : action}
 					button={button}
 					buttonClassName="webchat-list-template-header-button"
@@ -173,6 +174,7 @@ const ListItem: FC<IListItemProps> = props => {
 			) : (
 				<SecondaryButton
 					isActionButton
+					dataMessageId={dataMessageId}
 					action={shouldBeDisabled ? undefined : action}
 					button={button}
 					buttonClassName="webchat-list-template-element-button"

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -29,8 +29,15 @@ interface ITextWithButtonsProps {
 const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 	const { onSetMessageAnimated } = props;
 
-	const { action, message, config, onEmitAnalytics, messageParams, openXAppOverlay } =
-		useMessageContext();
+	const {
+		action,
+		message,
+		config,
+		onEmitAnalytics,
+		messageParams,
+		openXAppOverlay,
+		"data-message-id": dataMessageId,
+	} = useMessageContext();
 
 	const progressiveMessageRendering = !!config?.settings?.behavior?.progressiveMessageRendering;
 	const botOutputMaxWidthPercentage = config?.settings?.layout?.botOutputMaxWidthPercentage;
@@ -116,6 +123,7 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 
 			{(!progressiveMessageRendering || !stillAnimating) && (
 				<ActionButtons
+					dataMessageId={dataMessageId}
 					action={modifiedAction}
 					buttonClassName={classNames(
 						classes.button,


### PR DESCRIPTION
This PR fixes a regression where addition of useMessageContext hook in ActionButton component causes issue, as ActionButton component is used outside of the context provider (in webchat).

To fix this issue, the hook has been removed and dataMessageId prop is passed to Action button component from the parents only where it is necessary (List, Gallery and Text with buttons - as these are the messages that has postaback buttons that causes focus loss)

- Please test if the focus loss fix described in #137 is still working
- Pipeline should pass in https://github.com/Cognigy/Webchat/pull/122