### PR TITLE
#100891 Improvements for text resize

### DIFF
--- a/src/common/Typography/Typography.module.css
+++ b/src/common/Typography/Typography.module.css
@@ -1,87 +1,87 @@
 .h1-semibold {
 	font-family: Figtree;
-	font-size: 34px;
+	font-size: 2.125rem; /* 34px */
 	font-style: normal;
 	font-weight: 600;
-	line-height: 40.8px;
+	line-height: 2.55rem; /* 40.8px */
 }
 
 .h2-regular {
 	font-family: Figtree;
-	font-size: 18px;
+	font-size: 1.125rem; /* 18px */
 	font-style: normal;
 	font-weight: 400;
-	line-height: 23.4px;
+	line-height: 1.4625rem; /* 23.4px */
 }
 
 .h2-semibold {
 	font-family: Figtree;
-	font-size: 18px;
+	font-size: 1.125rem; /* 18px */
 	font-style: normal;
 	font-weight: 600;
-	line-height: 23.4px;
+	line-height: 1.4625rem; /* 23.4px */
 }
 
 .title1-regular {
 	font-family: Figtree;
-	font-size: 16px;
+	font-size: 1rem; /* 16px */
 	font-style: normal;
 	font-weight: 400;
-	line-height: 22.4px;
+	line-height: 1.4rem; /* 22.4px */
 }
 
 .title1-semibold {
 	font-family: Figtree;
-	font-size: 16px;
+	font-size: 1rem; /* 16px */
 	font-style: normal;
 	font-weight: 600;
-	line-height: 22.4px;
+	line-height: 1.4rem; /* 22.4px */
 }
 
 .title2-regular {
 	font-family: Figtree;
-	font-size: 12px;
+	font-size: 0.75rem; /* 12px */
 	font-style: normal;
 	font-weight: 400;
-	line-height: 16.8px;
+	line-height: 1.05rem; /* 16.8px */
 }
 
 .title2-semibold {
 	font-family: Figtree;
-	font-size: 12px;
+	font-size: 0.75rem; /* 12px */
 	font-style: normal;
 	font-weight: 600;
-	line-height: 15.6px;
+	line-height: 0.975rem; /* 15.6px */
 }
 
 .body-regular {
 	font-family: Figtree;
-	font-size: 14px;
+	font-size: 0.875rem; /* 14px */
 	font-style: normal;
 	font-weight: 400;
-	line-height: 19.6px;
+	line-height: 1.225rem; /* 19.6px */
 }
 
 .body-semibold {
 	font-family: Figtree;
-	font-size: 14px;
+	font-size: 0.875rem; /* 14px */
 	font-style: normal;
 	font-weight: 600;
-	line-height: 18.2px;
+	line-height: 1.1375rem; /* 18.2px */
 }
 
 .copy-medium {
 	font-family: Figtree;
-	font-size: 12px;
+	font-size: 0.75rem; /* 12px */
 	font-style: normal;
 	font-weight: 500;
-	line-height: 16.8px;
+	line-height: 1.05rem; /* 16.8px */
 }
 
 .cta-semibold {
 	font-family: Figtree;
-	font-size: 14px;
+	font-size: 0.875rem; /* 14px */
 	font-style: normal;
 	font-weight: 600;
-	line-height: 18.2px;
+	line-height: 1.1375rem; /* 18.2px */
 }

--- a/src/messages/Message.module.css
+++ b/src/messages/Message.module.css
@@ -11,14 +11,14 @@
 
 	color: var(--webchat-message-color, #1c1c1c);
 	font-weight: 400;
-	font-size: var(--webchat-message-font-size, 14px);
+	font-size: var(--webchat-message-font-size, 0.875rem); /* 14px */
 	line-height: 1.4;
-	margin-block: var(--webchat-message-margin-block, 24px);
-	margin-inline: var(--webchat-message-margin-inline, 20px);
+	margin-block: var(--webchat-message-margin-block, 1.5rem); /* 24px */
+	margin-inline: var(--webchat-message-margin-inline, 1.25rem); /* 20px */
 }
 
 .collated {
-	margin-block-start: calc(var(--webchat-message-margin-block, 24px) * -0.5);
+	margin-block-start: calc(var(--webchat-message-margin-block, 1.5rem) * -0.5); /* 24px */
 }
 
 .fullscreen {


### PR DESCRIPTION
This PR updates all font sizes from px to rem units for accessibility, ensuring that UI components scale properly when browser text size is increased up to 32px (200% of the default 16px), in accordance with WCAG 2.1 Level AA requirements.

Refer to https://github.com/Cognigy/Webchat/pull/124 for mre details. Please test this PR together with the webchat PR