### PR TITLE
fix: Add overflow-y auto for short screens in DatePicker

### DIFF
--- a/src/messages/DatePicker/DatePicker.module.css
+++ b/src/messages/DatePicker/DatePicker.module.css
@@ -744,6 +744,11 @@
 	display: none;
 }
 
+@media screen and (max-height: 780px) {
+	.wrapper .contentWrapper {
+		overflow-y: auto;
+	}
+}
 @media screen and (max-width: 575px) {
 	.wrapper .contentWrapper {
 		overflow-y: auto;


### PR DESCRIPTION
## Success Criteria
* Date picker is scrollable when the window height is below 760px

## How to test
1. Test the date picker by resizing the window height
2. Observe it is scrollable

