### PR TITLE
#106068 - Fix progressive rendering for quick replies

### DIFF
--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -7,7 +7,7 @@ import { useLiveRegion, useMessageContext, useRandomId } from "../hooks";
 
 import { getChannelPayload } from "src/utils";
 import ActionButtons from "src/common/ActionButtons/ActionButtons";
-import { IWebchatTemplateAttachment, IWebchatMessage } from "@cognigy/socket-client";
+import { IWebchatTemplateAttachment } from "@cognigy/socket-client";
 import classNames from "classnames";
 import { IStreamingMessage } from "../types";
 import { getTextWithButtonsContent } from "./helper";
@@ -55,20 +55,13 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 	);
 
 	useEffect(() => {
-		const messageConfig = message.data?._cognigy?._webchat as IWebchatMessage;
-		const textInQuickReplies = messageConfig?.message?.text;
-		const textInButtons = (messageConfig?.message?.attachment as IWebchatTemplateAttachment)
-			?.payload?.text;
-
-		// Check if neither text in quick-replies nor text in text-with-buttons is present
 		if (
 			progressiveMessageRendering &&
 			(isBotMessage || isEngagementMessage) &&
 			onSetMessageAnimated &&
 			message.id &&
 			message.animationState === "start" &&
-			!textInQuickReplies &&
-			!textInButtons
+			!text
 		) {
 			onSetMessageAnimated(message.id as string, "done");
 		}
@@ -79,7 +72,7 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 		onSetMessageAnimated,
 		message.id,
 		message.animationState,
-		message.data?._cognigy?._webchat,
+		text,
 	]);
 
 	const isSanitizeEnabled = !config?.settings?.layout?.disableHtmlContentSanitization;

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -63,7 +63,7 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 			message.animationState === "start" &&
 			!(message.data?._cognigy?._webchat as IWebchatMessage)?.message?.text
 		) {
-			// onSetMessageAnimated(message.id as string, "done");
+			onSetMessageAnimated(message.id as string, "done");
 		}
 	}, [
 		progressiveMessageRendering,

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -55,13 +55,20 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 	);
 
 	useEffect(() => {
+		const messageConfig = message.data?._cognigy?._webchat as IWebchatMessage;
+		const textInQuickReplies = messageConfig?.message?.text;
+		const textInButtons = (messageConfig?.message?.attachment as IWebchatTemplateAttachment)
+			?.payload?.text;
+
+		// Check if neither text in quick-replies nor text in text-with-buttons is present
 		if (
 			progressiveMessageRendering &&
 			(isBotMessage || isEngagementMessage) &&
 			onSetMessageAnimated &&
 			message.id &&
 			message.animationState === "start" &&
-			!(message.data?._cognigy?._webchat as IWebchatMessage)?.message?.text
+			!textInQuickReplies &&
+			!textInButtons
 		) {
 			onSetMessageAnimated(message.id as string, "done");
 		}

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -7,7 +7,7 @@ import { useLiveRegion, useMessageContext, useRandomId } from "../hooks";
 
 import { getChannelPayload } from "src/utils";
 import ActionButtons from "src/common/ActionButtons/ActionButtons";
-import { IWebchatTemplateAttachment } from "@cognigy/socket-client";
+import { IWebchatTemplateAttachment, IWebchatMessage } from "@cognigy/socket-client";
 import classNames from "classnames";
 import { IStreamingMessage } from "../types";
 import { getTextWithButtonsContent } from "./helper";
@@ -61,9 +61,9 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 			onSetMessageAnimated &&
 			message.id &&
 			message.animationState === "start" &&
-			!message.text
+			!(message.data?._cognigy?._webchat as IWebchatMessage)?.message?.text
 		) {
-			onSetMessageAnimated(message.id as string, "done");
+			// onSetMessageAnimated(message.id as string, "done");
 		}
 	}, [
 		progressiveMessageRendering,
@@ -72,7 +72,7 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 		onSetMessageAnimated,
 		message.id,
 		message.animationState,
-		message.text,
+		message.data?._cognigy?._webchat,
 	]);
 
 	const isSanitizeEnabled = !config?.settings?.layout?.disableHtmlContentSanitization;


### PR DESCRIPTION
This PR fixes an issue where progressive rendering was not working for text with buttons and quick replies

- Create a flow with different output types (text, quick-replies, text with buttons)
- Enable progressive rendering in endpoint settings
- Talk to the bot
- See if quick-reply, text with buttons and text messages are streamed