### PR TITLE
Feature/106049 setting to use custom html tags list

### DIFF
--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -2,7 +2,7 @@ import { FC, ReactElement } from "react";
 import classnames from "classnames";
 import { ActionButtonsProps } from "./ActionButtons";
 import { getWebchatButtonLabel, interpolateString, moveFocusToMessageFocusTarget } from "src/utils";
-import { useSanitize } from "src/sanitize";
+import { sanitizeHTML } from "src/sanitize";
 import { sanitizeUrl } from "@braintree/sanitize-url";
 import classes from "./ActionButton.module.css";
 import { LinkIcon } from "src/assets/svg";
@@ -42,8 +42,6 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		dataMessageId,
 	} = props;
 
-	const { sanitizeHTML } = useSanitize();
-
 	const buttonType =
 		"type" in button
 			? button.type
@@ -65,7 +63,10 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	if (!buttonType) return null;
 
 	const buttonLabel = getWebchatButtonLabel(button) || "";
-	const __html = sanitizeHTML(buttonLabel);
+	const customAllowedHtmlTags = config?.settings?.widgetSettings?.customAllowedHtmlTags || [];
+	const __html = config?.settings?.layout?.disableHtmlContentSanitization
+		? buttonLabel
+		: sanitizeHTML(buttonLabel, customAllowedHtmlTags);
 
 	const isPhoneNumber =
 		button.payload && (buttonType === "phone_number" || buttonType === "user_phone_number");

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -2,7 +2,7 @@ import { FC, ReactElement } from "react";
 import classnames from "classnames";
 import { ActionButtonsProps } from "./ActionButtons";
 import { getWebchatButtonLabel, interpolateString, moveFocusToMessageFocusTarget } from "src/utils";
-import { sanitizeHTML } from "src/sanitize";
+import { useSanitize } from "src/sanitize";
 import { sanitizeUrl } from "@braintree/sanitize-url";
 import classes from "./ActionButton.module.css";
 import { LinkIcon } from "src/assets/svg";
@@ -42,6 +42,8 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		dataMessageId,
 	} = props;
 
+	const { sanitizeHTML } = useSanitize();
+
 	const buttonType =
 		"type" in button
 			? button.type
@@ -63,9 +65,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	if (!buttonType) return null;
 
 	const buttonLabel = getWebchatButtonLabel(button) || "";
-	const __html = config?.settings?.layout?.disableHtmlContentSanitization
-		? buttonLabel
-		: sanitizeHTML(buttonLabel);
+	const __html = sanitizeHTML(buttonLabel);
 
 	const isPhoneNumber =
 		button.payload && (buttonType === "phone_number" || buttonType === "user_phone_number");

--- a/src/messages/Gallery/Gallery.tsx
+++ b/src/messages/Gallery/Gallery.tsx
@@ -13,6 +13,7 @@ import { IWebchatAttachmentElement, IWebchatTemplateAttachment } from "@cognigy/
 const Gallery: FC = () => {
 	const { message, config, "data-message-id": dataMessageId } = useMessageContext();
 	const isSanitizeEnabled = !config?.settings?.layout?.disableHtmlContentSanitization;
+	const customAllowedHtmlTags = config?.settings?.widgetSettings?.customAllowedHtmlTags;
 
 	const payload = getChannelPayload(message, config);
 	const { elements } =
@@ -53,8 +54,8 @@ const Gallery: FC = () => {
 
 	// Gather the gallery content for live region announcements
 	const slides = useMemo(
-		() => getGalleryContent(elements, isSanitizeEnabled),
-		[elements, isSanitizeEnabled],
+		() => getGalleryContent(elements, isSanitizeEnabled, customAllowedHtmlTags),
+		[elements, isSanitizeEnabled, customAllowedHtmlTags],
 	);
 
 	useLiveRegion({

--- a/src/messages/Gallery/GalleryItem.tsx
+++ b/src/messages/Gallery/GalleryItem.tsx
@@ -5,7 +5,7 @@ import buttonClasses from "src/common/Buttons/Buttons.module.css";
 import { useMessageContext, useRandomId } from "../hooks";
 import classnames from "classnames";
 import ActionButtons from "src/common/ActionButtons/ActionButtons";
-import { sanitizeHTML } from "src/sanitize";
+import { useSanitize } from "src/sanitize";
 import { sanitizeUrl } from "@braintree/sanitize-url";
 import { Typography } from "src/index";
 
@@ -26,10 +26,10 @@ const GalleryItem: FC<GallerySlideProps> = props => {
 	} = useMessageContext();
 	const hasExtraInfo = subtitle || (buttons && buttons?.length > 0);
 	const [isImageBroken, setImageBroken] = useState(false);
+	const { sanitizeHTML } = useSanitize();
 
-	const isSanitizeEnabled = !config?.settings?.layout?.disableHtmlContentSanitization;
-	const titleHtml = isSanitizeEnabled ? sanitizeHTML(title) : title;
-	const subtitleHtml = isSanitizeEnabled ? sanitizeHTML(subtitle) : subtitle;
+	const titleHtml = sanitizeHTML(title);
+	const subtitleHtml = sanitizeHTML(subtitle);
 
 	const titleId = useRandomId("webchatCarouselTemplateTitle");
 	const subtitleId = useRandomId("webchatCarouselTemplateSubtitle");

--- a/src/messages/Gallery/helper.ts
+++ b/src/messages/Gallery/helper.ts
@@ -11,23 +11,33 @@ export interface GalleryLiveContent {
  * Get text and buttons in a gallery, to be used during live region announcement.
  * @param elements - The gallery elements to process.
  * @param isSanitizeEnabled - Whether to sanitize HTML content.
+ * @param customAllowedHtmlTags - Custom HTML tags allowed for sanitization.
  * @returns An array of objects containing slide text and button labels.
  */
 export const getGalleryContent = (
 	elements: IWebchatAttachmentElement[] | undefined,
 	isSanitizeEnabled: boolean,
+	customAllowedHtmlTags: string[] = [],
 ): GalleryLiveContent[] => {
 	if (!elements || elements.length === 0) {
 		return [];
 	}
 
 	return elements.map((element: IWebchatAttachmentElement) => {
-		const title = sanitizeContent(element.title, isSanitizeEnabled);
+		const title = sanitizeContent(element.title, isSanitizeEnabled, customAllowedHtmlTags);
 
-		const subtitle = sanitizeContent(element.subtitle, isSanitizeEnabled);
+		const subtitle = sanitizeContent(
+			element.subtitle,
+			isSanitizeEnabled,
+			customAllowedHtmlTags,
+		);
 
 		const buttonLabels = (element.buttons || []).map(button =>
-			sanitizeContent(getWebchatButtonLabel(button), isSanitizeEnabled),
+			sanitizeContent(
+				getWebchatButtonLabel(button),
+				isSanitizeEnabled,
+				customAllowedHtmlTags,
+			),
 		);
 
 		const slideText = `${title}. ${subtitle}`;

--- a/src/messages/List/ListItem.tsx
+++ b/src/messages/List/ListItem.tsx
@@ -1,7 +1,7 @@
 import { FC, useMemo, KeyboardEvent, useEffect } from "react";
 import classes from "./List.module.css";
 import { useMessageContext, useRandomId } from "src/messages/hooks";
-import { sanitizeHTML } from "src/sanitize";
+import { useSanitize } from "src/sanitize";
 import { getBackgroundImage } from "src/utils";
 import { PrimaryButton, SecondaryButton } from "src/common/Buttons";
 import classnames from "classnames";
@@ -31,6 +31,8 @@ const ListItem: FC<IListItemProps> = props => {
 
 	const shouldBeDisabled = messageParams?.isConversationEnded;
 
+	const { sanitizeHTML } = useSanitize();
+
 	const handleClick = () => {
 		if (shouldBeDisabled || !default_action?.url) return;
 
@@ -50,10 +52,8 @@ const ListItem: FC<IListItemProps> = props => {
 		}
 	};
 
-	const isSanitizeEnabled = !config?.settings?.layout?.disableHtmlContentSanitization;
-
-	const titleHtml = isSanitizeEnabled ? sanitizeHTML(title) : title;
-	const subtitleHtml = isSanitizeEnabled ? sanitizeHTML(subtitle) : subtitle;
+	const titleHtml = sanitizeHTML(title);
+	const subtitleHtml = sanitizeHTML(subtitle);
 	const subtitleId = useRandomId("webchatListTemplateHeaderSubtitle");
 
 	const rootClasses = classnames(classes.listItemRoot, isHeaderElement && classes.headerRoot);

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import { useLiveRegion, useMessageContext } from "../hooks";
 import ChatBubble from "../../common/ChatBubble";
 import { replaceUrlsWithHTMLanchorElem } from "src/utils";
-import { sanitizeHTML } from "src/sanitize";
+import { useSanitize } from "src/sanitize";
 import { IStreamingMessage } from "../types";
 import classes from "./Text.module.css";
 import StreamingTextAnimation from "./StreamingTextAnimation";
@@ -25,6 +25,7 @@ interface TextProps {
 
 const Text: FC<TextProps> = props => {
 	const { message, config } = useMessageContext();
+	const { sanitizeHTML } = useSanitize();
 
 	const text = message?.text;
 	const source = message?.source;
@@ -65,9 +66,7 @@ const Text: FC<TextProps> = props => {
 		: replaceUrlsWithHTMLanchorElem(displayedText);
 
 	// HTML sanitization as needed
-	const __html = config?.settings?.layout?.disableHtmlContentSanitization
-		? enhancedURLsText
-		: sanitizeHTML(enhancedURLsText);
+	const __html = sanitizeHTML(enhancedURLsText);
 
 	useLiveRegion({
 		messageType: "text",

--- a/src/messages/Text/Text.tsx
+++ b/src/messages/Text/Text.tsx
@@ -66,11 +66,11 @@ const Text: FC<TextProps> = props => {
 		: replaceUrlsWithHTMLanchorElem(displayedText);
 
 	// HTML sanitization as needed
-	const __html = sanitizeHTML(enhancedURLsText);
+	const sanitizedContent = sanitizeHTML(enhancedURLsText);
 
 	useLiveRegion({
 		messageType: "text",
-		data: { text: __html },
+		data: { text: sanitizedContent },
 		validation: () => !props.ignoreLiveRegion,
 	});
 
@@ -86,13 +86,13 @@ const Text: FC<TextProps> = props => {
 						a: props => <a target="_blank" rel="noreferrer" {...props} />,
 					}}
 				>
-					{displayedText}
+					{sanitizedContent || displayedText}
 				</Markdown>
 			) : (
 				<p
 					id={props.id}
 					className={classNames(classes.text, props?.className)}
-					dangerouslySetInnerHTML={{ __html }}
+					dangerouslySetInnerHTML={{ __html: sanitizedContent }}
 				/>
 			)}
 			{/* If streaming + animate, show the typed effect */}

--- a/src/messages/TextWithButtons/TextWithButtons.tsx
+++ b/src/messages/TextWithButtons/TextWithButtons.tsx
@@ -76,10 +76,15 @@ const TextWithButtons: FC = (props: ITextWithButtonsProps) => {
 	]);
 
 	const isSanitizeEnabled = !config?.settings?.layout?.disableHtmlContentSanitization;
+	const customAllowedHtmlTags = config?.settings?.widgetSettings?.customAllowedHtmlTags;
 
 	const textWithButtonsContent = useMemo(() => {
-		return getTextWithButtonsContent({ text, buttons }, isSanitizeEnabled);
-	}, [text, buttons, isSanitizeEnabled]);
+		return getTextWithButtonsContent(
+			{ text, buttons },
+			isSanitizeEnabled,
+			customAllowedHtmlTags,
+		);
+	}, [text, buttons, isSanitizeEnabled, customAllowedHtmlTags]);
 
 	const { textContent, buttonLabels } = textWithButtonsContent;
 

--- a/src/messages/TextWithButtons/helper.ts
+++ b/src/messages/TextWithButtons/helper.ts
@@ -5,19 +5,25 @@ import { getWebchatButtonLabel } from "src/utils";
  * Get text and buttons in the message, to be used during live region announcement.
  * @param content - The data containing text and buttons.
  * @param isSanitizeEnabled - Whether to sanitize HTML content.
+ * @param customAllowedHtmlTags - Custom HTML tags allowed for sanitization.
  * @returns An array of objects containing slide text and button labels.
  */
 export const getTextWithButtonsContent = (
 	content: { text: string; buttons: [] },
 	isSanitizeEnabled: boolean,
+	customAllowedHtmlTags: string[] = [],
 ): any => {
 	const { text, buttons } = content;
-	const textContent = sanitizeContent(text, isSanitizeEnabled);
+	const textContent = sanitizeContent(text, isSanitizeEnabled, customAllowedHtmlTags);
 
 	const buttonLabels =
 		buttons?.map(button => {
 			const buttonLabel = getWebchatButtonLabel(button);
-			const sanitizedButtonLabel = sanitizeContent(buttonLabel, isSanitizeEnabled);
+			const sanitizedButtonLabel = sanitizeContent(
+				buttonLabel,
+				isSanitizeEnabled,
+				customAllowedHtmlTags,
+			);
 
 			return sanitizedButtonLabel;
 		}) || [];

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -291,6 +291,7 @@ export interface IWebchatSettings {
 		enableDefaultPreview: boolean;
 		ignoreLineBreaks: boolean;
 		STTLanguage: string;
+		customAllowedHtmlTags: string[];
 
 		sourceDirectionMapping: {
 			agent: TSourceDirection;

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -233,11 +233,13 @@ export const useSanitize = () => {
 	const isSanitizeEnabled = !config?.settings?.layout?.disableHtmlContentSanitization;
 	const customAllowedHtmlTags = config?.settings?.widgetSettings?.customAllowedHtmlTags;
 
+	const sanitizeHTML = (text: string) => {
+		if (!isSanitizeEnabled) return text;
+		return sanitizeHTMLWithConfig(text, customAllowedHtmlTags);
+	};
+
 	return {
-		sanitizeHTML: (text: string) => {
-			if (!isSanitizeEnabled) return text;
-			return sanitizeHTMLWithConfig(text, customAllowedHtmlTags);
-		},
+		sanitizeHTML,
 		isSanitizeEnabled,
 	};
 };


### PR DESCRIPTION
This PR 
- uses the new setting to allow custom HTML tags for message sanitization
- fixes a bug where text is never sanitized when 'Render Markdown' setting is enabled or an endpoint

Success Criteria:
- Texts in all message types are sanitized based on the provided html tags in customAllowedHtmlTags setting
- Sanitization should work in plain text and text with buttons messages when 'Render Markdown' setting is enabled

How to test:
- Test this PR together with the webchat PR https://github.com/Cognigy/Webchat/pull/142