### PR TITLE
Bug/104253 date picker buttons disabled state

### DIFF
--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -116,7 +116,7 @@ function customElements(pluginConfig: Config): Plugin {
 				}
 			} else {
 				button.setAttribute("tabindex", "0");
-				button.setAttribute("aria-disabled", "false");
+				button.removeAttribute("aria-disabled");
 				// Only add listener if it doesn't exist
 				if (!navKeydownHandlers.has(button)) {
 					const handler = (event: KeyboardEvent) => {
@@ -321,8 +321,6 @@ function customElements(pluginConfig: Config): Plugin {
 			],
 			onDayCreate: [
 				(_dObj, _dStr, _fp, dayElem) => {
-					dayElem.innerHTML = `<span class='dayInner'>${dayElem.innerHTML}</span>`;
-
 					// Set aria-disabled attribute based on flatpickr-disabled class
 					const isDisabled = dayElem.classList.contains("flatpickr-disabled");
 					if (isDisabled) {
@@ -330,6 +328,8 @@ function customElements(pluginConfig: Config): Plugin {
 					} else {
 						dayElem.removeAttribute("aria-disabled");
 					}
+
+					dayElem.innerHTML = `<span class='dayInner'>${dayElem.innerHTML}</span>`;
 				},
 				handleWeekNumbers,
 			],

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -322,6 +322,14 @@ function customElements(pluginConfig: Config): Plugin {
 			onDayCreate: [
 				(_dObj, _dStr, _fp, dayElem) => {
 					dayElem.innerHTML = `<span class='dayInner'>${dayElem.innerHTML}</span>`;
+					
+					// Set aria-disabled attribute based on flatpickr-disabled class
+					const isDisabled = dayElem.classList.contains("flatpickr-disabled");
+					if (isDisabled) {
+						dayElem.setAttribute("aria-disabled", "true");
+					} else {
+						dayElem.removeAttribute("aria-disabled");
+					}
 				},
 				handleWeekNumbers,
 			],

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -322,7 +322,7 @@ function customElements(pluginConfig: Config): Plugin {
 			onDayCreate: [
 				(_dObj, _dStr, _fp, dayElem) => {
 					dayElem.innerHTML = `<span class='dayInner'>${dayElem.innerHTML}</span>`;
-					
+
 					// Set aria-disabled attribute based on flatpickr-disabled class
 					const isDisabled = dayElem.classList.contains("flatpickr-disabled");
 					if (isDisabled) {

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -16,6 +16,9 @@ function customElements(pluginConfig: Config): Plugin {
 	return function (fp: Instance) {
 		const { arrowIcon, customTranslations } = pluginConfig;
 
+		// Store event handlers for navigation buttons
+		const navKeydownHandlers = new WeakMap<HTMLElement, (event: KeyboardEvent) => void>();
+
 		function buildTimeArrows() {
 			if (!fp?.config?.enableTime) return;
 			const arrowUp = fp?.timeContainer?.getElementsByClassName("arrowUp");
@@ -82,33 +85,86 @@ function customElements(pluginConfig: Config): Plugin {
 			const nextButton = fp?.calendarContainer?.querySelector(
 				".flatpickr-next-month",
 			) as HTMLElement;
-			if (prevButton) {
-				const prevButtonAriaLabel = customTranslations?.ariaLabels?.datePickerPreviousMonth;
-				prevButton.setAttribute("aria-label", prevButtonAriaLabel || "Previous month");
-				prevButton.setAttribute("role", "button");
-				if (!prevButton.classList.contains("flatpickr-disabled")) {
-					prevButton.setAttribute("tabindex", "0");
-					prevButton.addEventListener("keydown", event => {
+
+			updateNavButtonAccessibility(prevButton, "prev");
+			updateNavButtonAccessibility(nextButton, "next");
+		}
+
+		// Update accessibility attributes for navigation buttons based on their enabled/disabled state
+		function updateNavButtonAccessibility(
+			button: HTMLElement | null,
+			direction: "prev" | "next",
+		) {
+			if (!button) return;
+
+			const isPrev = direction === "prev";
+			const ariaLabel = isPrev
+				? customTranslations?.ariaLabels?.datePickerPreviousMonth || "Previous month"
+				: customTranslations?.ariaLabels?.datePickerNextMonth || "Next month";
+
+			button.setAttribute("aria-label", ariaLabel);
+			button.setAttribute("role", "button");
+
+			if (button.classList.contains("flatpickr-disabled")) {
+				button.setAttribute("aria-disabled", "true");
+				button.removeAttribute("tabindex");
+				// Remove the handler if it exists
+				const handler = navKeydownHandlers.get(button);
+				if (handler) {
+					button.removeEventListener("keydown", handler);
+					navKeydownHandlers.delete(button);
+				}
+			} else {
+				button.setAttribute("tabindex", "0");
+				button.setAttribute("aria-disabled", "false");
+				// Only add listener if it doesn't exist
+				if (!navKeydownHandlers.has(button)) {
+					const handler = (event: KeyboardEvent) => {
 						if (event.key === "Enter" || event.key === " ") {
 							event.preventDefault();
-							fp.changeMonth(-1); // Move to the previous month
+							const targetButton = event.target as HTMLElement;
+							const isPrevButton =
+								targetButton.classList.contains("flatpickr-prev-month");
+							fp.changeMonth(isPrevButton ? -1 : 1);
 						}
-					});
+					};
+					navKeydownHandlers.set(button, handler);
+					button.addEventListener("keydown", handler);
 				}
 			}
-			if (nextButton) {
-				const nextButtonAriaLabel = customTranslations?.ariaLabels?.datePickerNextMonth;
-				nextButton.setAttribute("aria-label", nextButtonAriaLabel || "Next month");
-				nextButton.setAttribute("role", "button");
-				if (!nextButton.classList.contains("flatpickr-disabled")) {
-					nextButton.setAttribute("tabindex", "0");
-					nextButton.addEventListener("keydown", event => {
-						if (event.key === "Enter" || event.key === " ") {
-							event.preventDefault();
-							fp.changeMonth(1); // Move to the next month
-						}
-					});
-				}
+		}
+
+		// Observe navigation buttons for class changes
+		function observeNavButtons() {
+			const prevButton = fp?.calendarContainer?.querySelector(
+				".flatpickr-prev-month",
+			) as HTMLElement;
+			const nextButton = fp?.calendarContainer?.querySelector(
+				".flatpickr-next-month",
+			) as HTMLElement;
+
+			if (prevButton && !prevButton.dataset.observed) {
+				const observer = new MutationObserver(() => {
+					updateNavButtonAccessibility(prevButton, "prev");
+				});
+
+				observer.observe(prevButton, {
+					attributes: true,
+					attributeFilter: ["class"],
+				});
+				prevButton.dataset.observed = "true";
+			}
+
+			if (nextButton && !nextButton.dataset.observed) {
+				const observer = new MutationObserver(() => {
+					updateNavButtonAccessibility(nextButton, "next");
+				});
+
+				observer.observe(nextButton, {
+					attributes: true,
+					attributeFilter: ["class"],
+				});
+				nextButton.dataset.observed = "true";
 			}
 		}
 
@@ -256,6 +312,7 @@ function customElements(pluginConfig: Config): Plugin {
 				setMonthSelectAlly,
 				setYearSelectAlly,
 				setNavButtonsAlly,
+				observeNavButtons,
 				observeMonthSelector,
 
 				() => {

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -20,6 +20,7 @@ import file from "test/fixtures/file.json";
 import AdaptiveCardPayloads from "test/fixtures/adaptiveCards.json";
 
 import datePicker from "test/fixtures/datepicker/singleDate.json";
+import datePickerMinMax from "test/fixtures/datepicker/singleDateWithMinMax.json";
 import datePickerMultiple from "test/fixtures/datepicker/multiple.json";
 import datePickerRange from "test/fixtures/datepicker/range.json";
 import datePickerWeeks from "test/fixtures/datepicker/weekNumbers.json";
@@ -292,6 +293,7 @@ const screens: TScreen[] = [
 		anchor: "datepicker",
 		messages: [
 			{ message: datePicker as IMessage },
+			{ message: datePickerMinMax as IMessage },
 			{ message: datePickerMultiple as IMessage },
 			{ message: datePickerRange as IMessage },
 			{ message: datePickerWeeks as IMessage },

--- a/test/fixtures/datepicker/singleDateWithMinMax.json
+++ b/test/fixtures/datepicker/singleDateWithMinMax.json
@@ -1,0 +1,31 @@
+{
+	"text": "",
+	"data": {
+		"_plugin": {
+			"type": "date-picker",
+			"data": {
+				"eventName": "Calendar",
+				"locale": "en",
+				"enableTime": "true",
+				"defaultDate": "2025-07-15T15:42:00.000+02:00",
+				"mode": "single",
+				"wantDisable": false,
+				"enable_disable": null,
+				"function_enable_disable": "",
+				"minDate": "2025-07-04T15:42:00.000+02:00",
+				"maxDate": "2025-10-04T15:42:00.000+02:00",
+				"openPickerButtonText": "Single date with min and max",
+				"cancelButtonText": "",
+				"submitButtonText": "Confirm Selection",
+				"time_24hr": "",
+				"dateFormat": "",
+				"defaultHour": 12,
+				"defaultMinute": 30,
+				"hourIncrement": 1,
+				"minuteIncrement": 5,
+				"noCalendar": false,
+				"weekNumbers": false
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR 
- Adds aria-disabled attribute on the previous/Next month buttons and the individual calendar days when they are disabled
- Fixes a bug where prev/next month buttons where not keyboard accessibile when their state changes from disabled to enabled

How to test:

**Test 1**
- Open the datepicker tab in the demo page. 
- Open the Single date with min-max calendar element
- Navigate via keyboard inside the calender. Initiall prev month button is disabled and will not get keyboard focus, as the min date is July 4th. 
- Check if the prev month has aria-disabled=true
- Navigate to next month button and click it
- Now, the prev button will be enabled
- Reverse navigate and see if you can focus prev-month button via keyboard
- Check if aria-disabled is set to false or removed


**Test 2:**
- Inspect the disabled dates out of the min-max range (4th July to 4th Octomer in the demo)
- See if the aria-disabled=true is added to the days