### PR TITLE
Update react-player Solving Unwanted Dynamic Imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"moment": "^2.30.1",
 				"react-flatpickr": "^3.10.13",
 				"react-markdown": "9.0.3",
-				"react-player": "2.16.0",
+				"react-player": "2.2.0",
 				"react-tooltip": "5.28.0",
 				"react-transition-group": "4.4.5",
 				"rehype-raw": "7.0.0",
@@ -9460,9 +9460,10 @@
 			}
 		},
 		"node_modules/react-player": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/react-player/-/react-player-2.16.0.tgz",
-			"integrity": "sha512-mAIPHfioD7yxO0GNYVFD1303QFtI3lyyQZLY229UEAp/a10cSW+hPcakg0Keq8uWJxT2OiT/4Gt+Lc9bD6bJmQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/react-player/-/react-player-2.2.0.tgz",
+			"integrity": "sha512-TsUn7NL3IWmVwoeU+Jbbbrq6+2HQYsiAyC75deWI0dCkJA3InbR194VBJJiYIZvFL+tUZAcbBDHt+tYyPA0Wjg==",
+			"license": "MIT",
 			"dependencies": {
 				"deepmerge": "^4.0.0",
 				"load-script": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"moment": "^2.30.1",
 		"react-flatpickr": "^3.10.13",
 		"react-markdown": "9.0.3",
-		"react-player": "2.16.0",
+		"react-player": "2.2.0",
 		"react-tooltip": "5.28.0",
 		"react-transition-group": "4.4.5",
 		"rehype-raw": "7.0.0",

--- a/src/messages/Audio/Audio.tsx
+++ b/src/messages/Audio/Audio.tsx
@@ -3,7 +3,6 @@ import ReactPlayer from "react-player";
 import classes from "./Audio.module.css";
 import classnames from "classnames";
 import Controls from "./Controls";
-import { OnProgressProps } from "react-player/base";
 import { useLiveRegion, useMessageContext } from "src/messages/hooks";
 import { getChannelPayload } from "src/utils";
 import { IWebchatAudioAttachment } from "@cognigy/socket-client";
@@ -28,7 +27,7 @@ const Audio: FC = () => {
 			if (!chatHistory?.contains(document.activeElement)) return;
 
 			setTimeout(() => {
-				player.getInternalPlayer()?.focus();
+				(player.getInternalPlayer() as HTMLVideoElement)?.focus();
 			}, 100);
 		},
 		[config?.settings?.widgetSettings?.enableAutoFocus],
@@ -42,7 +41,7 @@ const Audio: FC = () => {
 		setPlaying(false);
 	}, []);
 
-	const handleProgress = useCallback((state: OnProgressProps) => {
+	const handleProgress = useCallback((state: any) => {
 		setProgress(state.played);
 	}, []);
 

--- a/src/messages/Video/Video.tsx
+++ b/src/messages/Video/Video.tsx
@@ -35,7 +35,7 @@ const Video: FC = () => {
 			if (!chatHistory?.contains(document.activeElement)) return;
 
 			setTimeout(() => {
-				player.getInternalPlayer()?.focus();
+				(player.getInternalPlayer() as HTMLVideoElement)?.focus();
 			}, 100);
 		},
 		[config?.settings?.widgetSettings?.enableAutoFocus],
@@ -43,7 +43,7 @@ const Video: FC = () => {
 
 	// Prevent focus loss from video preview button when the video starts playing by focusing the internal player
 	const handleOnStart = () => {
-		const internalPlayer = videoPlayerRef.current?.getInternalPlayer();
+		const internalPlayer = videoPlayerRef.current?.getInternalPlayer() as HTMLVideoElement;
 		internalPlayer?.focus();
 	};
 


### PR DESCRIPTION
Previously used version of the react-player dependency had a piece of code which would intefier with our preparations for esm build in Webchat. The next minor version of the react-player solves the issue.

# How to test
- Video / Audio should continue work. Open demo page to check 
`npm ci && npm run dev`