### PR TITLE
fix: externalize react/jsx-runtime to prevent React 19 crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"url": "https://github.com/Cognigy/chat-components"
 	},
 	"exports": {
+		"types": "./dist/index.d.ts",
 		"import": "./dist/chat-components.js",
 		"require": "./dist/chat-components.js"
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
 			formats: ["es"],
 		},
 		rollupOptions: {
-			external: ["react", "react-dom"],
+			external: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
 			output: {
 				format: "es",
 				inlineDynamicImports: true,


### PR DESCRIPTION
## Summary

- Add `react/jsx-runtime` and `react/jsx-dev-runtime` to Rollup `external` list so they are not bundled inline
- Add `types` condition to `exports` field for proper type resolution with `moduleResolution: "bundler"`

## Problem

The build externalized `react` and `react-dom` but not the jsx-runtime subpath imports. This caused Vite to bundle React 18's jsx-runtime inline in `dist/chat-components.js`. Consumers using React 19 (e.g. the Interaction Panel MFE via Module Federation) crashed on load:

```
TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
```

The inlined runtime accesses `React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner` which was removed in React 19. It also creates elements with `Symbol.for("react.element")` instead of React 19's `Symbol.for("react.transitional.element")`, causing error #525 at render time.

## Test plan

- [ ] `npm run build` succeeds
- [ ] `dist/chat-components.js` no longer contains `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` or `ReactCurrentOwner`
- [ ] `dist/chat-components.js` imports `react/jsx-runtime` as an external dependency
- [ ] Existing React 18 consumers (Webchat) still work
- [ ] React 19 consumers (Interaction Panel MFE) load without crashes

🤖 Generated with [Claude Code](https://claude.ai/code)