### PR TITLE
release/v0.70.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.69.0",
+	"version": "0.70.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.69.0",
+			"version": "0.70.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
 				"@fontsource/figtree": "5.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.69.0",
+	"version": "0.70.0",
 	"type": "module",
 	"main": "./dist/chat-components.js",
 	"repository": {


### PR DESCRIPTION
## Summary
- Bump version to 0.70.0
- Includes: fix: externalize react/jsx-runtime to prevent React 19 crashes (#239)