### PR TITLE
ci: deploy demo page to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy demo to GitHub Pages
+
+on:
+    push:
+        branches: [main]
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+concurrency:
+    group: pages
+    cancel-in-progress: false
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24.x
+                  cache: npm
+            - run: npm ci
+            - run: npm run build:demo
+            - uses: actions/configure-pages@v5
+            - uses: actions/upload-pages-artifact@v3
+              with:
+                  path: dist-demo
+
+    deploy:
+        needs: build
+        runs-on: ubuntu-latest
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - id: deployment
+              uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-demo
 dist-ssr
 *.local
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"scripts": {
 		"dev": "vite --host",
 		"build": "tsc && vite build && node scripts/postbuild-secure-patch.mjs",
-		"build:demo": "vite build --config vite.demo.config.ts",
+		"build:demo": "tsc --noEmit && vite build --config vite.demo.config.ts",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
 		"preview": "vite preview",
 		"prepack": "npm run build",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	"scripts": {
 		"dev": "vite --host",
 		"build": "tsc && vite build && node scripts/postbuild-secure-patch.mjs",
+		"build:demo": "vite build --config vite.demo.config.ts",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
 		"preview": "vite preview",
 		"prepack": "npm run build",

--- a/vite.demo.config.ts
+++ b/vite.demo.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 		outDir: "dist-demo",
 		emptyOutDir: true,
 		target: "es2020",
-		sourcemap: true,
+		sourcemap: "hidden",
 	},
 	resolve: {
 		alias: {

--- a/vite.demo.config.ts
+++ b/vite.demo.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+import svgr from "vite-plugin-svgr";
+
+export default defineConfig({
+	base: "/chat-components/",
+	plugins: [react(), svgr()],
+	build: {
+		outDir: "dist-demo",
+		emptyOutDir: true,
+		target: "es2020",
+		sourcemap: true,
+	},
+	resolve: {
+		alias: {
+			src: "/src",
+			test: "/test",
+		},
+	},
+});


### PR DESCRIPTION
## Summary

Publish the existing `test/demo.tsx` showcase as a static site on GitHub Pages so consumers can see the components live without cloning the repo.

## What changed

- **`vite.demo.config.ts`** — new SPA-mode Vite config. Builds `index.html` → `test/demo.tsx` with `base: "/chat-components/"` and outputs to `dist-demo/`. Does **not** externalize React or use `build.lib`, so the demo is self-contained.
- **`package.json`** — adds `build:demo` script. The existing `build` (library bundle → `dist/`) is untouched.
- **`.github/workflows/deploy-pages.yml`** — runs `npm ci && npm run build:demo` on push to `main` (and `workflow_dispatch`), then uploads `dist-demo/` via `actions/upload-pages-artifact@v3` and deploys via `actions/deploy-pages@v4`. Standard `pages: write` + `id-token: write` permissions, `concurrency: pages` with `cancel-in-progress: false`.
- **`.gitignore`** — adds `dist-demo`.

Once merged, the site will be served at https://cognigy.github.io/chat-components/ and a `github-pages` environment will appear in the repo sidebar.

## Reviewer notes

- **Repo settings change required before first deploy:** under *Settings → Pages*, change **Source** from "Deploy from a branch" to **GitHub Actions**. No branch needs to be selected.
- The demo bundles `test/fixtures/*.json` as production assets — fine for a public demo, but worth flagging since `test/` was previously a test-only directory.
- `index.html` references `/favicon.svg` which doesn't exist in the repo. Pre-existing 404 (also broken in `npm run dev`); not addressed here.
- Demo bundle is ~1.5 MB unminified (the Vite warning is expected — chat-components + adaptivecards + swiper + react-player adapters). Can be code-split later if needed.

## Test plan

- [x] `npm run build:demo` produces `dist-demo/index.html` with assets correctly prefixed `/chat-components/...`
- [x] `npx vite preview --config vite.demo.config.ts` serves the demo at `http://localhost:4173/chat-components/` and renders all message types
- [ ] After merge + Pages "Source: GitHub Actions" setting, the workflow deploys successfully and the published URL renders the demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)