### PR TITLE
AB#136232: update c26 theme primary palette purple → blue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.71.0",
+	"version": "0.72.0",
 	"type": "module",
 	"main": "./dist/chat-components.js",
 	"repository": {

--- a/src/theme-c26.css
+++ b/src/theme-c26.css
@@ -110,8 +110,8 @@ article.c26 {
 	--cc-datepicker-label-left: var(--c26-datepicker-label-left, 0);
 
 	/* Primary palette — affects buttons, links, focus rings via --cc-primary-color consumers */
-	--cc-primary-color: var(--c26-primary-color, #6e56cf);
-	--cc-primary-color-hover: var(--c26-primary-color-hover, #5c46b8);
+	--cc-primary-color: var(--c26-primary-color, #126bce);
+	--cc-primary-color-hover: var(--c26-primary-color-hover, #17569b);
 	--cc-primary-color-focus: var(--c26-primary-color-focus, var(--cc-primary-color));
 	--cc-primary-color-disabled: var(
 		--c26-primary-color-disabled,
@@ -128,11 +128,11 @@ article.c26 {
 	--cc-primary-contrast-color: var(--c26-primary-contrast-color, #ffffff);
 
 	/* Primary shade variants — used by buttons, inputs, checkboxes, focus rings */
-	--cc-primary-color-50: var(--c26-primary-color-50, #e0dbf5);
-	--cc-primary-color-100: var(--c26-primary-color-100, #c8bff0);
-	--cc-primary-color-300: var(--c26-primary-color-300, #8f73e3);
-	--cc-primary-color-700: var(--c26-primary-color-700, #4a369f);
-	--cc-primary-color-900: var(--c26-primary-color-900, #2a1b66);
+	--cc-primary-color-50: var(--c26-primary-color-50, #e5f2ff);
+	--cc-primary-color-100: var(--c26-primary-color-100, #d2e7fe);
+	--cc-primary-color-300: var(--c26-primary-color-300, #5ea9fd);
+	--cc-primary-color-700: var(--c26-primary-color-700, #164479);
+	--cc-primary-color-900: var(--c26-primary-color-900, #0b233d);
 
 	/* Input surfaces — AdaptiveCards text/date/time/select/textarea */
 	--cc-input-border-color: var(--c26-input-border-color, #d1d5db);
@@ -141,7 +141,7 @@ article.c26 {
 	--cc-input-focus-ring: var(--c26-input-focus-ring, var(--cc-primary-color-50));
 
 	/* Bubble backgrounds */
-	--cc-background-user-message: var(--c26-background-user-message, #f2f0fa);
+	--cc-background-user-message: var(--c26-background-user-message, #ecf5fe);
 	--cc-background-bot-message: var(--c26-background-bot-message, var(--cc-primary-color));
 	--cc-background-agent-message: var(--c26-background-agent-message, var(--cc-primary-color));
 
@@ -218,21 +218,21 @@ article.c26 .adaptivecard-wrapper select:focus-visible {
 article.c26 .adaptivecard-wrapper [type="date"] {
 	background-image: var(
 		--c26-input-date-icon,
-		url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M3 0.75C3 0.335786 3.33579 0 3.75 0C4.16421 0 4.5 0.335786 4.5 0.75V3H11V0.75C11 0.335786 11.3358 0 11.75 0C12.1642 0 12.5 0.335786 12.5 0.75V3H14C15.1046 3 16 3.89543 16 5V14C16 15.1046 15.1046 16 14 16H2C0.895431 16 0 15.1046 0 14V5C0 3.89543 0.895431 3 2 3H3V0.75ZM1.5 6H14.5V14C14.5 14.2761 14.2761 14.5 14 14.5H2C1.72386 14.5 1.5 14.2761 1.5 14V6Z' fill='%236e56cf'/%3E%3C/svg%3E")
+		url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M3 0.75C3 0.335786 3.33579 0 3.75 0C4.16421 0 4.5 0.335786 4.5 0.75V3H11V0.75C11 0.335786 11.3358 0 11.75 0C12.1642 0 12.5 0.335786 12.5 0.75V3H14C15.1046 3 16 3.89543 16 5V14C16 15.1046 15.1046 16 14 16H2C0.895431 16 0 15.1046 0 14V5C0 3.89543 0.895431 3 2 3H3V0.75ZM1.5 6H14.5V14C14.5 14.2761 14.2761 14.5 14 14.5H2C1.72386 14.5 1.5 14.2761 1.5 14V6Z' fill='%23126bce'/%3E%3C/svg%3E")
 	);
 }
 
 article.c26 .adaptivecard-wrapper [type="time"] {
 	background-image: var(
 		--c26-input-time-icon,
-		url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8 14.5C11.5899 14.5 14.5 11.5899 14.5 8C14.5 4.41015 11.5899 1.5 8 1.5C4.41015 1.5 1.5 4.41015 1.5 8C1.5 11.5899 4.41015 14.5 8 14.5ZM8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16Z' fill='%236e56cf'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M11.0303 12.0303C10.7374 12.3232 10.2626 12.3232 9.96967 12.0303L7.25 9.31066L7.25 4C7.25 3.58579 7.58578 3.25 8 3.25C8.41421 3.25 8.75 3.58579 8.75 4L8.75 8.68934L11.0303 10.9697C11.3232 11.2626 11.3232 11.7374 11.0303 12.0303Z' fill='%236e56cf'/%3E%3C/svg%3E")
+		url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8 14.5C11.5899 14.5 14.5 11.5899 14.5 8C14.5 4.41015 11.5899 1.5 8 1.5C4.41015 1.5 1.5 4.41015 1.5 8C1.5 11.5899 4.41015 14.5 8 14.5ZM8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16Z' fill='%23126bce'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M11.0303 12.0303C10.7374 12.3232 10.2626 12.3232 9.96967 12.0303L7.25 9.31066L7.25 4C7.25 3.58579 7.58578 3.25 8 3.25C8.41421 3.25 8.75 3.58579 8.75 4L8.75 8.68934L11.0303 10.9697C11.3232 11.2626 11.3232 11.7374 11.0303 12.0303Z' fill='%23126bce'/%3E%3C/svg%3E")
 	);
 }
 
 article.c26 .adaptivecard-wrapper select {
 	background-image: var(
 		--c26-select-chevron-icon,
-		url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M1.34923 4.24022C1.76855 3.8808 2.39985 3.92936 2.75927 4.34869L8.00002 10.4629L13.2408 4.34869C13.6002 3.92936 14.2315 3.8808 14.6508 4.24022C15.0701 4.59965 15.1187 5.23095 14.7593 5.65027L9.51853 11.7645C8.72034 12.6957 7.2797 12.6957 6.4815 11.7645L1.24076 5.65027C0.881339 5.23095 0.929901 4.59965 1.34923 4.24022Z' fill='%236e56cf'/%3E%3C/svg%3E")
+		url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M1.34923 4.24022C1.76855 3.8808 2.39985 3.92936 2.75927 4.34869L8.00002 10.4629L13.2408 4.34869C13.6002 3.92936 14.2315 3.8808 14.6508 4.24022C15.0701 4.59965 15.1187 5.23095 14.7593 5.65027L9.51853 11.7645C8.72034 12.6957 7.2797 12.6957 6.4815 11.7645L1.24076 5.65027C0.881339 5.23095 0.929901 4.59965 1.34923 4.24022Z' fill='%23126bce'/%3E%3C/svg%3E")
 	);
 }
 


### PR DESCRIPTION
Wires up the new UCL blue primary palette inside the c26 theme. Realigns chat-components fallbacks with `@cognigy-internal/ui-component-library@1.15.0` (which switched primary purple → blue in commit `4d3365d`). Bumps package version to `0.72.0`.

Linked work item: AB#136232

# Success criteria

- C26 bot bubbles, agent bubbles, primary buttons, action buttons, focus rings, and SVG input icons render in the new blue palette when no consumer-side `--c26-*` overrides are present.
- Consumers that already drive `--primary-*` (e.g. Interaction Panel) are not affected — they keep resolving via their own bridge.
- No public API change; only `theme-c26.css` fallback hex values + 4 SVG `fill` colors are changed.

# How to test

1. `npm ci && npm run build` in chat-components.
2. `npm run storybook` and inspect any C26 story (Message bubbles, Action button, AdaptiveCards inputs, date/time pickers, select chevron).
3. Confirm bot/agent bubbles render solid blue (`#126bce`), user bubble light blue (`#ecf5fe`), date/time/select icons recolored to `#126bce`.
4. Toggle a consumer that omits `--c26-*` overrides and confirm previous purple has been replaced.

# Color mapping

| `--cc-*` token | Old (purple) | New (UCL blue) |
|---|---|---|
| `--cc-primary-color` | `#6e56cf` | `#126bce` |
| `--cc-primary-color-hover` | `#5c46b8` | `#17569b` |
| `--cc-primary-color-50` | `#e0dbf5` | `#e5f2ff` |
| `--cc-primary-color-100` | `#c8bff0` | `#d2e7fe` |
| `--cc-primary-color-300` | `#8f73e3` | `#5ea9fd` |
| `--cc-primary-color-700` | `#4a369f` | `#164479` |
| `--cc-primary-color-900` | `#2a1b66` | `#0b233d` |
| `--cc-background-user-message` | `#f2f0fa` | `#ecf5fe` |

Plus 4 inline SVG `fill='%236e56cf'` → `fill='%23126bce'` (date, time x2, chevron icons — CSS vars do not resolve inside `data:` URIs).

# Security
- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications

# Additional considerations
- [ ] This PR might have performance implications

# Documentation Considerations
Visual change only; no API surface or behavior change. Release notes should mention the c26 theme palette refresh.