### PR TITLE
AB#139373: Fix date-picker open button wrap + overlay scroll in c26 theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.74.0",
+	"version": "0.75.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.74.0",
+			"version": "0.75.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
 				"@fontsource/figtree": "5.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.74.0",
+	"version": "0.75.0",
 	"type": "module",
 	"main": "./dist/chat-components.js",
 	"repository": {

--- a/src/theme-c26.css
+++ b/src/theme-c26.css
@@ -288,3 +288,36 @@ article.c26 [data-testid="video-message"] svg circle {
 article.c26 [data-testid="video-message"] svg path {
 	fill: var(--cc-primary-contrast-color);
 }
+
+/* Date Picker "Open" button — expand for multi-line labels; border-box keeps the
+ * single-line baseline height (padding must not inflate min-height). */
+article.c26 button[aria-controls^="webchat-plugin-date-picker-"] {
+	box-sizing: border-box;
+	height: auto;
+	min-height: var(--cc-primary-button-height, 36px);
+	padding: 8px;
+}
+
+/* Date Picker overlay — scroll only the calendar body, keep the footer visible.
+ * overflow:hidden stops the wrapper itself scrolling (the responsive media
+ * queries set overflow-y:auto on it), so only the content scrolls. */
+article.c26 .webchat-plugin-date-picker > :not(.webchat-plugin-date-picker-header) {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	min-height: 0;
+	overflow: hidden;
+}
+
+article.c26 .webchat-plugin-date-picker-content {
+	/* Shrink + scroll when the picker is taller than the panel, but never grow
+	 * to fill — growing would push the footer button to the very bottom. */
+	flex: 0 1 auto;
+	min-height: 0;
+	overflow-x: hidden;
+	overflow-y: auto;
+}
+
+article.c26 .webchat-plugin-date-picker-footer {
+	flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary

Moves date-picker styling fixes into the **c26 theme** so consumers (currently the Cognigy interaction-panel) no longer carry local CSS overrides against the date-picker plugin's internal DOM.

Two fixes, both scoped to `article.c26` (default theme unaffected):

1. **"Open" button** — let multi-line label text expand the button (`height: auto; min-height; padding`) instead of clipping. The c26 theme lowers `--cc-primary-button-height` to 36px with no padding, which clipped longer labels. Targeted via the button's `aria-controls` relationship to the date-picker dialog rather than a `data-testid` (not a test hook).
2. **Calendar overlay** — make only the calendar body scroll while the confirm footer stays visible, for containers slightly shorter than the full picker (a case the existing viewport media query misses).

## Context

Raised in interaction-panel PR Cognigy/cognigy#13077, where these rules currently live as local overrides. Reviewer feedback: this belongs in the chat-components c26 theme. The interaction-panel PR will drop the local CSS and bump to the new release. (The remaining interaction-panel change — a popover containing-block fix — stays there, as the message-origin popover is interaction-panel-only.)

## Changes

- `src/theme-c26.css` — four `article.c26`-scoped rules appended.

## How to test

1. `npm run build` (clean).
2. In the demo under the **c26** theme: a long "Open" label wraps and the button grows (no clipping); in a height-constrained container the calendar body scrolls and the confirm button stays visible.
3. Confirm the **default** theme date-picker is unchanged.

## Release

Intended for a **0.73.0** (minor) release once approved — handled per your release process.