### PR TITLE
fix(audio): fix SVG fill override and popover flip in constrained panels (AB#137478)

### DIFF
--- a/src/messages/Audio/Audio.module.css
+++ b/src/messages/Audio/Audio.module.css
@@ -233,6 +233,10 @@ article button.menuItem:focus-visible {
 article button.menuItem svg {
 	flex-shrink: 0;
 	color: var(--cc-audio-menu-text, var(--cc-black-30));
+	/* Prevent host-page CSS resets (e.g. Tailwind preflight `svg { fill: currentColor }`)
+	 * from overriding the SVG's own fill="none" presentation attribute on stroke-based icons. */
+	fill: none;
+	stroke: currentColor;
 }
 
 article button.menuItemActive {

--- a/src/messages/Audio/Controls.tsx
+++ b/src/messages/Audio/Controls.tsx
@@ -65,10 +65,27 @@ const Controls: FC<ControlsProps> = props => {
 	const downloadTranscriptLinkRef = useRef<HTMLAnchorElement>(null);
 	const menuRef = useRef<HTMLDivElement>(null);
 	const menuButtonRef = useRef<HTMLButtonElement>(null);
+	const scrollContainerRef = useRef<HTMLElement | null>(null);
 	const [menuOpen, setMenuOpen] = useState(false);
 	const [menuView, setMenuView] = useState<"main" | "speed">("main");
 	const [speedAnnouncement, setSpeedAnnouncement] = useState("");
 	const { config } = useMessageContext();
+
+	// Find the nearest scrollable ancestor once on mount so Radix uses it as the
+	// collision boundary instead of the viewport. This matters in constrained host
+	// panels (e.g. Interaction Panel MFE) where the viewport bottom is close to the
+	// trigger even when the scroll container has plenty of room below.
+	useEffect(() => {
+		let el = menuButtonRef.current?.parentElement ?? null;
+		while (el && el !== document.body) {
+			const { overflow, overflowY } = getComputedStyle(el);
+			if (/(auto|scroll|overlay)/.test(overflow + overflowY)) {
+				scrollContainerRef.current = el;
+				break;
+			}
+			el = el.parentElement;
+		}
+	}, []);
 
 	// Focus the relevant item for the current view (APG menu button pattern).
 	// preventScroll avoids the browser scrolling the item into view — that scroll
@@ -394,6 +411,7 @@ const Controls: FC<ControlsProps> = props => {
 							align="end"
 							sideOffset={6}
 							collisionPadding={8}
+							collisionBoundary={scrollContainerRef.current ?? undefined}
 							onKeyDown={handleMenuKeyDown}
 							onEscapeKeyDown={e => {
 								// APG: Escape closes the innermost menu. In the speed submenu,


### PR DESCRIPTION
## What

Two visual bugs introduced when upgrading `@cognigy/chat-components` in host apps that apply a Tailwind v4 preflight or render the widget in a fixed-height panel.

**SVG fill override** — Tailwind's preflight sets `svg { fill: currentColor }`, which overrides the `fill="none"` presentation attribute on stroke-based icons (e.g. `CirclePlayIcon`), filling them with a solid colour. Fix: explicit `fill: none; stroke: currentColor` on `.menuItem svg` in the CSS module.

**Popover opening upward** — Radix's `Popover.Content` uses the viewport as the collision boundary by default. In a fixed-height host panel (e.g. Interaction Panel MFE) audio triggers near the lower half of the panel are close to the viewport bottom, so Radix flips the menu upward even though the scroll container has room. Fix: find the nearest scrollable ancestor on mount and pass it as `collisionBoundary`.

## Test plan

- [ ] Options menu opens downward in the chat-components demo
- [ ] In Interaction Panel MFE (upgraded to this version) menu opens downward regardless of audio position
- [ ] Stroke-based icons (CirclePlayIcon etc.) render without blue fill
- [ ] `npm test` — 148/148 pass