### PR TITLE
fix(datepicker): keyboard & screen-reader accessibility for the calendar grid (AB#118957)

### DIFF
--- a/src/messages/DatePicker/DatePicker.module.css
+++ b/src/messages/DatePicker/DatePicker.module.css
@@ -425,6 +425,18 @@
 	background-color: var(--cc-black-95);
 }
 
+/* Visible focus ring for the roving-tabindex day. The .flatpickr-day cell receives DOM
+   focus; the ring hugs the inner pill so keyboard users can see which date is focused. */
+.wrapper .content :global(.flatpickr-day) {
+	outline: none;
+}
+
+.wrapper .content :global(.flatpickr-day:focus-visible .dayInner),
+.wrapper .content :global(.flatpickr-day:focus .dayInner) {
+	outline: 2px solid var(--cc-primary-color);
+	outline-offset: 2px;
+}
+
 .wrapper .content :global(.flatpickr-day.flatpickr-disabled .dayInner),
 .wrapper .content :global(.flatpickr-day.prevMonthDay.flatpickr-disabled .dayInner),
 .wrapper .content :global(.flatpickr-day.nextMonthDay.flatpickr-disabled .dayInner) {

--- a/src/messages/DatePicker/DatePicker.tsx
+++ b/src/messages/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, KeyboardEvent, useMemo, useRef } from "react";
+import { FC, useState, KeyboardEvent, useMemo, useRef, useEffect } from "react";
 import classes from "./DatePicker.module.css";
 import classnames from "classnames";
 import Flatpickr from "react-flatpickr";
@@ -22,8 +22,18 @@ const DatePicker: FC = () => {
 
 	const openButtonRef = useRef<HTMLButtonElement>(null);
 	const datePickerRef = useRef<HTMLDivElement>(null);
+	const headingRef = useRef<HTMLElement>(null);
 
 	const datePickerHeading = useRandomId("webchatDatePickerHeading");
+
+	// When the dialog opens, move focus to its heading so the screen reader announces the
+	// dialog name. The user can then Tab/arrow into the calendar grid, where the
+	// selected/today date is the single focusable cell (roving tabindex).
+	useEffect(() => {
+		if (showPicker) {
+			headingRef.current?.focus();
+		}
+	}, [showPicker]);
 
 	if (!message?.data?._plugin || message.data._plugin.type !== "date-picker") return;
 
@@ -135,6 +145,8 @@ const DatePicker: FC = () => {
 						<span className={classes.left}></span>
 						<span className={classes.center}>
 							<Typography
+								ref={headingRef}
+								tabIndex={-1}
 								variant="h2-semibold"
 								component="h4"
 								className="webchat-list-template-header-title"

--- a/src/messages/DatePicker/DatePicker.tsx
+++ b/src/messages/DatePicker/DatePicker.tsx
@@ -21,6 +21,7 @@ const DatePicker: FC = () => {
 	const [currentDate, setCurrentDate] = useState("");
 
 	const openButtonRef = useRef<HTMLButtonElement>(null);
+	const datePickerRef = useRef<HTMLDivElement>(null);
 
 	const datePickerHeading = useRandomId("webchatDatePickerHeading");
 
@@ -120,10 +121,10 @@ const DatePicker: FC = () => {
 			</PrimaryButton>
 			{showPicker && (
 				<div
+					ref={datePickerRef}
 					id={`webchat-plugin-date-picker-${message.id}`}
 					className={classnames(classes.wrapper, "webchat-plugin-date-picker")}
 					onKeyDown={handleKeyDown}
-					tabIndex={0}
 					role="dialog"
 					aria-modal="true"
 					aria-labelledby={datePickerHeading}
@@ -137,6 +138,7 @@ const DatePicker: FC = () => {
 								variant="h2-semibold"
 								component="h4"
 								className="webchat-list-template-header-title"
+								id={datePickerHeading}
 							>
 								{eventName || "Calendar"}
 							</Typography>
@@ -146,7 +148,6 @@ const DatePicker: FC = () => {
 							aria-label={closeDatePickerLabel}
 							className={classes.right}
 							data-testid="button-close"
-							autoFocus
 						>
 							<CloseIcon />
 						</button>

--- a/src/messages/DatePicker/DatePicker.tsx
+++ b/src/messages/DatePicker/DatePicker.tsx
@@ -103,7 +103,10 @@ const DatePicker: FC = () => {
 		}
 		if (shiftTabKeyPress) {
 			// Handle Reverse Tab Navigation
-			if (event.target === firstFocusable) {
+			if (event.target === firstFocusable || event.target === headingRef.current) {
+				// The heading is focused programmatically on open via tabIndex=-1, so it is not
+				// part of getFocusableElements() and would not be treated as firstFocusable. Trap
+				// Shift+Tab here too, otherwise focus escapes the aria-modal dialog on first keypress.
 				event.preventDefault();
 				lastFocusable?.focus();
 			} else if (event.target === firstTimePickerField) {

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -10,6 +10,13 @@ export interface Config {
 /**
  * Custom flatpickr plugin that adds some DOM elements for webchat v3 design
  * It handles timeContainer, weekNumbers, and custom accessibility logic for some datepicker elements.
+ *
+ * The calendar grid follows the W3C ARIA APG "Date Picker Dialog" pattern:
+ * - `.flatpickr-rContainer` is the `role="grid"` (it wraps the weekday header row and the day rows)
+ * - the weekday header is a `role="row"` of `role="columnheader"` cells
+ * - the day cells are `role="gridcell"`, grouped 7-per-`role="row"`
+ * - focus is managed with a roving tabindex: exactly one day is `tabindex="0"`, the rest `-1`
+ * - arrow keys / Home / End / PageUp / PageDown move real DOM focus between days
  */
 function customElements(pluginConfig: Config): Plugin {
 	// fp`refers to the Flatpickr instance
@@ -20,6 +27,10 @@ function customElements(pluginConfig: Config): Plugin {
 		const navKeydownHandlers = new WeakMap<HTMLElement, (event: KeyboardEvent) => void>();
 
 		let liveRegion: HTMLElement | null = null;
+		// When true, a month/year change is being driven by our PageUp/PageDown handler, which
+		// will announce the landed date itself; suppress the month/year-only announcement so the
+		// two don't compete in the live region.
+		let suppressMonthYearAnnounce = false;
 
 		function createLiveRegion() {
 			if (!fp?.calendarContainer) return;
@@ -36,50 +47,67 @@ function customElements(pluginConfig: Config): Plugin {
 			fp.calendarContainer.appendChild(liveRegion);
 		}
 
-		function announceMonthYear() {
-			if (!liveRegion) return;
-			const monthName = fp.l10n.months.longhand[fp.currentMonth];
-			const year = fp.currentYear;
-			liveRegion.textContent = `${monthName} ${year}`;
+		// Push a message into the polite live region so NVDA speaks it. Re-set even when the
+		// text is unchanged (clear first) so repeated navigation to equivalent labels still
+		// announces.
+		function announce(message: string) {
+			if (!liveRegion || !message) return;
+			// Clearing first guarantees a DOM change is observed even if the text repeats.
+			liveRegion.textContent = "";
+			liveRegion.textContent = message;
 		}
 
-		function focusCurrentDay() {
-			if (!fp?.calendarContainer) return;
-			const selectedDay =
+		// Announce the visible month/year — used when the month/year is changed via the nav
+		// buttons or the month/year dropdowns, where focus stays on the control (not a day),
+		// so no day-focus announcement fires.
+		function announceMonthYear() {
+			if (suppressMonthYearAnnounce) return;
+			const monthName = fp.l10n.months.longhand[fp.currentMonth];
+			announce(`${monthName} ${fp.currentYear}`);
+		}
+
+		// Announce a focused day's full spoken date (e.g. "June 23, 2026"). Driven on every
+		// day focus change. NVDA does not reliably re-announce a roving-focus gridcell on its
+		// own, so this live-region message is what the user actually hears when focus moves
+		// between dates via arrows / Home / End / PageUp / PageDown. Because the message
+		// includes the month and year, it also covers the month/year change on Page navigation.
+		function announceDay(dayElem: HTMLElement | null) {
+			const label = dayElem?.getAttribute("aria-label");
+			if (label) announce(label);
+		}
+
+		// Returns the currently "selectable" day cells of the visible month, i.e. days that
+		// belong to the current month and are not disabled. Used for roving-focus targets.
+		function getDayCells(): HTMLElement[] {
+			return Array.from(
+				fp?.calendarContainer?.querySelectorAll<HTMLElement>(".dayContainer .flatpickr-day") ||
+					[],
+			);
+		}
+
+		// Roving tabindex: make exactly one day focusable (tabindex="0"); all others tabindex="-1".
+		// Optionally move real DOM focus to it so the screen reader announces the date.
+		function setActiveDay(dayElem: HTMLElement | null, options?: { focus?: boolean }) {
+			if (!dayElem) return;
+			getDayCells().forEach(day => {
+				day.setAttribute("tabindex", day === dayElem ? "0" : "-1");
+			});
+			if (options?.focus) {
+				dayElem.focus();
+			}
+		}
+
+		// Pick the day cell that should be the initial roving-focus target:
+		// the selected day, else today, else the first enabled day of the current month.
+		function getInitialActiveDay(): HTMLElement | null {
+			if (!fp?.calendarContainer) return null;
+			return (
 				fp.calendarContainer.querySelector<HTMLElement>(".flatpickr-day.selected") ||
 				fp.calendarContainer.querySelector<HTMLElement>(".flatpickr-day.today") ||
 				fp.calendarContainer.querySelector<HTMLElement>(
-					".flatpickr-day:not(.flatpickr-disabled):not(.prevMonthDay):not(.nextMonthDay)",
-				);
-			if (selectedDay) {
-				const daysContainer = fp?.calendarContainer?.getElementsByClassName(
-					"flatpickr-innerContainer",
-				)[0] as HTMLElement;
-				if (daysContainer) {
-					// Use aria-activedescendant pattern for grid navigation
-					if (!selectedDay.id) {
-						selectedDay.id = `fp-day-${Math.random().toString(36).substring(2, 9)}`;
-					}
-					daysContainer.setAttribute("aria-activedescendant", selectedDay.id);
-				}
-			}
-		}
-
-		function updateDayAriaActivedescendant() {
-			if (!fp?.calendarContainer) return;
-			const daysContainer = fp?.calendarContainer?.getElementsByClassName(
-				"flatpickr-innerContainer",
-			)[0] as HTMLElement;
-			const selectedDay =
-				fp.calendarContainer.querySelector<HTMLElement>(".flatpickr-day.selected") ||
-				fp.calendarContainer.querySelector<HTMLElement>(".flatpickr-day.today");
-
-			if (daysContainer && selectedDay) {
-				if (!selectedDay.id) {
-					selectedDay.id = `fp-day-${Math.random().toString(36).substring(2, 9)}`;
-				}
-				daysContainer.setAttribute("aria-activedescendant", selectedDay.id);
-			}
+					".dayContainer .flatpickr-day:not(.flatpickr-disabled):not(.prevMonthDay):not(.nextMonthDay)",
+				)
+			);
 		}
 
 		function buildTimeArrows() {
@@ -231,38 +259,106 @@ function customElements(pluginConfig: Config): Plugin {
 			}
 		}
 
-		// Remove tabindex from calender container and set it to innerContainer
+		// Number of columns in the calendar grid (7 days of the week).
+		const GRID_COLS = 7;
+
+		// Apply the grid structure roles (role="grid" / "columnheader").
+		// Day cells keep their position semantics via aria-rowindex/aria-colindex applied
+		// per-render in applyDayGridIndices() — we deliberately do NOT wrap them in physical
+		// row elements, because flatpickr's native arrow navigation indexes the day cells as
+		// direct children of `.dayContainer`; wrapping them breaks that navigation.
 		function setDateSelectAlly() {
+			// The calendar container is not the grid; keep it out of the tab order.
 			fp?.calendarContainer?.setAttribute("tabindex", "-1");
-			const daysContainer = fp?.calendarContainer?.getElementsByClassName(
-				"flatpickr-innerContainer",
-			)[0];
-			if (daysContainer) {
-				daysContainer.setAttribute("tabindex", "0");
-				daysContainer.setAttribute("role", "grid");
-				daysContainer.setAttribute(
+
+			// `.flatpickr-rContainer` wraps both the weekday header row and the day grid,
+			// so it is the correct element to carry role="grid".
+			const grid = fp?.calendarContainer?.querySelector<HTMLElement>(".flatpickr-rContainer");
+			if (grid) {
+				grid.setAttribute("role", "grid");
+				grid.setAttribute(
 					"aria-label",
 					customTranslations?.ariaLabels?.datePickerGridLabel || "Calendar",
 				);
-				daysContainer.setAttribute(
+				grid.setAttribute(
 					"aria-description",
 					customTranslations?.ariaLabels?.datePickerGridDescription ||
 						"Use arrow keys to navigate through dates",
 				);
+				grid.setAttribute("aria-colcount", String(GRID_COLS));
+				// 1 weekday header row + 6 week rows.
+				grid.setAttribute("aria-rowcount", "7");
 			}
 
-			const weekdayContainer =
-				fp?.calendarContainer?.querySelector(".flatpickr-weekdays");
+			// `.flatpickr-innerContainer` is just a layout wrapper now (focus lives on a day cell).
+			const innerContainer = fp?.calendarContainer?.getElementsByClassName(
+				"flatpickr-innerContainer",
+			)[0];
+			innerContainer?.removeAttribute("tabindex");
+			innerContainer?.removeAttribute("role");
+			innerContainer?.removeAttribute("aria-activedescendant");
+
+			// Weekday header is row 1 of the grid; each weekday is a columnheader.
+			const weekdayContainer = fp?.calendarContainer?.querySelector(".flatpickr-weekdays");
 			if (weekdayContainer) {
 				weekdayContainer.setAttribute("role", "row");
+				weekdayContainer.setAttribute("aria-rowindex", "1");
 			}
-			const weekdaySpans = fp?.calendarContainer?.querySelectorAll(
-				".flatpickr-weekday",
-			);
-			weekdaySpans?.forEach(span => {
+			const weekdaySpans = fp?.calendarContainer?.querySelectorAll(".flatpickr-weekday");
+			weekdaySpans?.forEach((span, index) => {
 				span.setAttribute("role", "columnheader");
 				span.setAttribute("abbr", span.textContent?.trim() || "");
+				span.setAttribute("aria-colindex", String((index % GRID_COLS) + 1));
 			});
+		}
+
+		// Give the flat list of day cells grid row/column semantics via aria-rowindex and
+		// aria-colindex (instead of physical role="row" wrappers, which would break flatpickr's
+		// native arrow navigation). The `.dayContainer` is the rowgroup. Flatpickr rebuilds
+		// `.dayContainer` on every render, so this must run after each rebuild.
+		function applyDayGridIndices() {
+			const dayContainer =
+				fp?.calendarContainer?.querySelector<HTMLElement>(".dayContainer");
+			if (!dayContainer) return;
+
+			dayContainer.setAttribute("role", "rowgroup");
+
+			const dayCells = Array.from(
+				dayContainer.querySelectorAll<HTMLElement>(":scope > .flatpickr-day"),
+			);
+			dayCells.forEach((cell, i) => {
+				// Day rows start at grid row 2 (row 1 is the weekday header).
+				cell.setAttribute("aria-rowindex", String(Math.floor(i / GRID_COLS) + 2));
+				cell.setAttribute("aria-colindex", String((i % GRID_COLS) + 1));
+			});
+		}
+
+		// Re-apply grid row roles and restore the single focusable day whenever flatpickr
+		// rebuilds the day grid (default-date application, redraws, month/year changes).
+		// A MutationObserver on the stable `.flatpickr-days` container is the most robust hook,
+		// matching the defensive pattern used for the nav buttons and month selector.
+		function observeDayGrid() {
+			const daysContainer =
+				fp?.calendarContainer?.querySelector<HTMLElement>(".flatpickr-days");
+			if (!daysContainer || daysContainer.dataset.gridObserved === "true") return;
+			daysContainer.dataset.gridObserved = "true";
+
+			const reapply = () => {
+				applyDayGridIndices();
+				// Keep exactly one focusable day. Preserve the existing roving target if it is
+				// still in the DOM; otherwise fall back to the selected/today/first day.
+				const existing = daysContainer.querySelector<HTMLElement>(
+					".flatpickr-day[tabindex='0']",
+				);
+				setActiveDay(existing || getInitialActiveDay(), { focus: false });
+			};
+
+			// `.dayContainer` is replaced on every flatpickr render; re-apply on each childList
+			// change. We only set attributes (not move nodes), so this never re-triggers itself.
+			const observer = new MutationObserver(() => reapply());
+			observer.observe(daysContainer, { childList: true, subtree: true });
+			// Apply once immediately for the initial render.
+			reapply();
 		}
 
 		// Observe month selector for changes and set tabindex again to 0. This is to ensure that the month selector is focusable all the time
@@ -389,62 +485,134 @@ function customElements(pluginConfig: Config): Plugin {
 			}
 		}
 
-		// Handle arrow key navigation for grid using aria-activedescendant
-		function setGridArrowKeyNavigation() {
-			const daysContainer = fp?.calendarContainer?.getElementsByClassName(
-				"flatpickr-innerContainer",
-			)[0] as HTMLElement;
+		// In-month day cells of the visible month (excludes prev/next-month overflow cells).
+		function getInMonthCells(): HTMLElement[] {
+			return getDayCells().filter(
+				c =>
+					!c.classList.contains("prevMonthDay") && !c.classList.contains("nextMonthDay"),
+			);
+		}
 
-			if (!daysContainer) return;
+		// After a month/year change, move roving focus to the day with the same day-of-month
+		// number (APG PageUp/PageDown behavior). If that day does not exist in the new month
+		// (e.g. Jan 31 -> Feb), focus the last day of the month instead.
+		function focusSameOrLastDayOfMonth(dayNumber: number) {
+			const inMonth = getInMonthCells();
+			if (inMonth.length === 0) {
+				setActiveDay(getInitialActiveDay(), { focus: true });
+				return;
+			}
+			const sameDay = inMonth.find(c => Number(c.textContent?.trim()) === dayNumber);
+			const target = sameDay || inMonth[inMonth.length - 1];
+			setActiveDay(target, { focus: true });
+		}
+
+		// Keyboard navigation for the calendar grid.
+		//
+		// IMPORTANT: flatpickr already implements Arrow-key navigation natively (focusOnDay /
+		// getNextAvailableDay), including disabled-day skipping and crossing month boundaries.
+		// We deliberately do NOT handle Arrow keys here — doing so previously ran two handlers in
+		// parallel that fought over focus (each arrow moved focus twice, and focus was lost after
+		// a month change). Instead we let flatpickr own the arrows and only add the keys it lacks:
+		// Home / End (within the week) and PageUp / PageDown (prev/next month, same day number).
+		// A separate `focusin` listener (see syncRovingTabindex) keeps the roving tabindex aligned
+		// with whatever day flatpickr focuses, so Tab can always re-enter the grid.
+		function setGridKeyNavigation() {
+			const daysContainer =
+				fp?.calendarContainer?.querySelector<HTMLElement>(".flatpickr-days");
+			if (!daysContainer || daysContainer.dataset.keyboardBound === "true") return;
+			daysContainer.dataset.keyboardBound = "true";
+
+			const cols = 7;
 
 			daysContainer.addEventListener("keydown", (event: KeyboardEvent) => {
-				if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(event.key)) {
-					return;
-				}
-
-				event.preventDefault();
-
-				const allDays = Array.from(
-					fp?.calendarContainer?.querySelectorAll<HTMLElement>(".flatpickr-day") || [],
-				);
-				const activeDayId = daysContainer.getAttribute("aria-activedescendant");
-				const currentDay = activeDayId
-					? fp?.calendarContainer?.querySelector(`#${activeDayId}`)
-					: null;
-				const currentIndex = currentDay ? allDays.indexOf(currentDay as HTMLElement) : -1;
-
-				let nextIndex = currentIndex;
-
-				// Get grid dimensions (7 columns for days of week)
-				const cols = 7;
+				const currentDay = event.target as HTMLElement;
+				if (!currentDay?.classList?.contains("flatpickr-day")) return;
 
 				switch (event.key) {
-					case "ArrowDown":
-						nextIndex = currentIndex + cols;
-						break;
-					case "ArrowUp":
-						nextIndex = currentIndex - cols;
-						break;
-					case "ArrowRight":
-						nextIndex = currentIndex + 1;
-						break;
-					case "ArrowLeft":
-						nextIndex = currentIndex - 1;
-						break;
-				}
-
-				// Clamp to valid range
-				if (nextIndex >= 0 && nextIndex < allDays.length) {
-					const nextDay = allDays[nextIndex];
-					if (!nextDay.classList.contains("flatpickr-disabled")) {
-						if (!nextDay.id) {
-							nextDay.id = `fp-day-${Math.random().toString(36).substring(2, 9)}`;
+					case "Home":
+					case "End": {
+						// First (col 0) / last (col 6) day of the focused week. Operate on the full
+						// day list so week columns line up regardless of disabled days.
+						event.preventDefault();
+						event.stopPropagation();
+						const cells = getDayCells();
+						const idx = cells.indexOf(currentDay);
+						if (idx === -1) return;
+						const weekStart = idx - (idx % cols);
+						const targetIdx =
+							event.key === "Home" ? weekStart : weekStart + (cols - 1);
+						const target = cells[targetIdx];
+						if (target && !target.classList.contains("flatpickr-disabled")) {
+							setActiveDay(target, { focus: true });
 						}
-						daysContainer.setAttribute("aria-activedescendant", nextDay.id);
-						// Announce the date via live region
-						announceMonthYear();
+						return;
 					}
+					case "PageUp":
+					case "PageDown": {
+						// Prev/next month (Shift = year), keeping the same day-of-month number.
+						// stopPropagation so flatpickr's keydown never also acts on this event.
+						event.preventDefault();
+						event.stopPropagation();
+						const dayNumber = Number(currentDay.textContent?.trim());
+						const forward = event.key === "PageDown";
+						// Suppress flatpickr's month/year-change announcement; focusing the landed
+						// day below announces the full date (which already includes month + year).
+						suppressMonthYearAnnounce = true;
+						if (event.shiftKey) {
+							fp.changeYear(fp.currentYear + (forward ? 1 : -1));
+						} else {
+							fp.changeMonth(forward ? 1 : -1);
+						}
+						suppressMonthYearAnnounce = false;
+						focusSameOrLastDayOfMonth(dayNumber);
+						return;
+					}
+					case "Tab": {
+						// Let the browser move focus out of the grid natively (forward to the time
+						// fields / submit, backward to the month-year nav). We only stop the event
+						// reaching flatpickr's own keydown, which otherwise hijacks Shift+Tab and
+						// sends focus to its hidden input (a dead end). We do NOT preventDefault, so
+						// native tabbing proceeds; and the dialog's focus trap does not act on a day
+						// cell (never the first/last focusable), so stopping propagation is safe.
+						event.stopPropagation();
+						return;
+					}
+					case "Enter":
+					case " ":
+					case "Spacebar": {
+						// Select the focused day. flatpickr selects on Enter natively, but Space
+						// does not select, so handle both here and stop flatpickr double-acting.
+						event.preventDefault();
+						event.stopPropagation();
+						currentDay.click();
+						return;
+					}
+					// Arrow keys intentionally fall through to flatpickr's native handler.
 				}
+			});
+		}
+
+		// On every day-cell focus: (1) keep the roving tabindex (a single tabindex="0" day)
+		// aligned with the focused day — whether moved by flatpickr's native arrow handling or by
+		// our Home/End/Page handlers — so Tab always re-enters the grid on the right day; and
+		// (2) announce the focused date via the live region, since NVDA does not reliably speak a
+		// roving-focus gridcell on its own.
+		function syncRovingTabindex() {
+			const daysContainer =
+				fp?.calendarContainer?.querySelector<HTMLElement>(".flatpickr-days");
+			if (!daysContainer || daysContainer.dataset.focusinBound === "true") return;
+			daysContainer.dataset.focusinBound = "true";
+
+			daysContainer.addEventListener("focusin", (event: FocusEvent) => {
+				const target = event.target as HTMLElement;
+				if (!target?.classList?.contains("flatpickr-day")) return;
+				if (target.getAttribute("tabindex") !== "0") {
+					getDayCells().forEach(day => {
+						day.setAttribute("tabindex", day === target ? "0" : "-1");
+					});
+				}
+				announceDay(target);
 			});
 		}
 
@@ -460,14 +628,17 @@ function customElements(pluginConfig: Config): Plugin {
 				observeNavButtons,
 				observeMonthSelector,
 				createLiveRegion,
-				focusCurrentDay,
-				setGridArrowKeyNavigation,
+				setGridKeyNavigation,
+				syncRovingTabindex,
+				// Apply grid row roles + the initial roving-focus day, and keep them correct
+				// across every flatpickr rebuild. Does not steal focus — the dialog focuses its
+				// heading on open; the first Tab into the grid lands on the focusable day.
+				observeDayGrid,
 
 				() => {
 					fp?.loadedPlugins?.push("customElements");
 				},
 			],
-			onMonthChange: [announceMonthYear],
 			onYearChange: [announceMonthYear],
 			onDayCreate: [
 				(_dObj, _dStr, _fp, dayElem) => {
@@ -480,31 +651,57 @@ function customElements(pluginConfig: Config): Plugin {
 					}
 
 					dayElem.innerHTML = `<span class='dayInner'>${dayElem.innerHTML}</span>`;
-					// All day cells are not focusable by default (using aria-activedescendant pattern)
+					// Real gridcell so the screen reader exposes it as the focused cell of the grid
+					// (the previous role="presentation" hid it, which broke arrow-key navigation).
+					dayElem.setAttribute("role", "gridcell");
+					// Roving tabindex default: not focusable until promoted by setActiveDay().
 					dayElem.setAttribute("tabindex", "-1");
-					// Use presentation role so individual dates don't announce as clickable items
-					dayElem.setAttribute("role", "presentation");
-					// Ensure each date has a unique ID for aria-activedescendant
+					// Mark the selected day for assistive tech.
+					if (dayElem.classList.contains("selected")) {
+						dayElem.setAttribute("aria-selected", "true");
+					} else {
+						dayElem.removeAttribute("aria-selected");
+					}
+					// Ensure each date has a unique ID (used by tests / potential labelling).
 					if (!dayElem.id) {
 						dayElem.id = `fp-day-${Math.random().toString(36).substring(2, 9)}`;
 					}
-					// Add aria-label with full date so screen reader announces "June 1" when navigated
-					const dateNum = dayElem.textContent?.trim();
-					if (dateNum && !isDisabled) {
-						const monthName = fp.l10n.months.longhand[fp.currentMonth];
-						dayElem.setAttribute("aria-label", `${monthName} ${dateNum}, ${fp.currentYear}`);
+					// Spoken aria-label so the screen reader announces e.g. "June 1, 2026" when the
+					// day is focused. Use the cell's own date (dayElem.dateObj) rather than the
+					// visible month, so prev/next-month days announce their real month — not "June 31".
+					const cellDate = (dayElem as unknown as { dateObj?: Date }).dateObj;
+					if (cellDate) {
+						const monthName = fp.l10n.months.longhand[cellDate.getMonth()];
+						dayElem.setAttribute(
+							"aria-label",
+							`${monthName} ${cellDate.getDate()}, ${cellDate.getFullYear()}`,
+						);
 					}
 				},
 				handleWeekNumbers,
 			],
-			onValueUpdate: [upsertTimeArrows, updateDayAriaActivedescendant],
-			onMonthChange: [
-				announceMonthYear,
+			onValueUpdate: [
+				upsertTimeArrows,
+				// Selecting a date rebuilds the day grid synchronously (flatpickr calls
+				// buildDays() before firing onValueUpdate). Re-apply the grid indices and restore
+				// a single focusable day so the roving-tabindex invariant survives selection, and
+				// mark the newly selected gridcell.
 				() => {
-					// Re-attach arrow key navigation when month changes
-					setGridArrowKeyNavigation();
+					applyDayGridIndices();
+					const selected = fp?.calendarContainer?.querySelector<HTMLElement>(
+						".dayContainer .flatpickr-day.selected",
+					);
+					getDayCells().forEach(day => {
+						if (day.classList.contains("selected")) {
+							day.setAttribute("aria-selected", "true");
+						} else {
+							day.removeAttribute("aria-selected");
+						}
+					});
+					setActiveDay(selected || getInitialActiveDay(), { focus: false });
 				},
 			],
+			onMonthChange: [announceMonthYear],
 		};
 	};
 }

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -29,6 +29,13 @@ function customElements(pluginConfig: Config): Plugin {
 		// Store event handlers for navigation buttons
 		const navKeydownHandlers = new WeakMap<HTMLElement, (event: KeyboardEvent) => void>();
 
+		// All long-lived MutationObservers created by this plugin. They observe DOM that flatpickr
+		// owns, so they outlive a single render; collect them and disconnect every one in onDestroy
+		// to avoid leaking observers (and the nodes they reference) when the instance is destroyed.
+		const observers: MutationObserver[] = [];
+		// Pending timeouts (e.g. the month-selector debounce) cleared on destroy.
+		const timeouts: ReturnType<typeof setTimeout>[] = [];
+
 		let liveRegion: HTMLElement | null = null;
 		// When true, a month/year change is being driven by our PageUp/PageDown handler, which
 		// will announce the landed date itself; suppress the month/year-only announcement so the
@@ -247,6 +254,7 @@ function customElements(pluginConfig: Config): Plugin {
 					attributes: true,
 					attributeFilter: ["class"],
 				});
+				observers.push(observer);
 				prevButton.dataset.observed = "true";
 			}
 
@@ -259,6 +267,7 @@ function customElements(pluginConfig: Config): Plugin {
 					attributes: true,
 					attributeFilter: ["class"],
 				});
+				observers.push(observer);
 				nextButton.dataset.observed = "true";
 			}
 		}
@@ -377,6 +386,7 @@ function customElements(pluginConfig: Config): Plugin {
 			// observer's childList watch.
 			const observer = new MutationObserver(() => refreshGridAfterRebuild());
 			observer.observe(daysContainer, { childList: true, subtree: true });
+			observers.push(observer);
 			// Apply once immediately for the initial render.
 			refreshGridAfterRebuild();
 		}
@@ -401,6 +411,7 @@ function customElements(pluginConfig: Config): Plugin {
 					timeout = setTimeout(() => {
 						monthSelector.setAttribute("tabindex", "0");
 					}, 100);
+					timeouts.push(timeout);
 				});
 
 				observer.observe(monthSelector, {
@@ -408,6 +419,7 @@ function customElements(pluginConfig: Config): Plugin {
 					childList: false,
 					subtree: false,
 				});
+				observers.push(observer);
 				monthSelector.dataset.observed = "true";
 			}
 		}
@@ -791,6 +803,18 @@ function customElements(pluginConfig: Config): Plugin {
 			});
 		}
 
+		// Disconnect every observer and clear pending timeouts created by this plugin. flatpickr
+		// calls onDestroy when the instance is destroyed/unmounted; without this the long-lived
+		// observers (nav buttons, day grid, month selector) would keep referencing detached DOM.
+		function cleanup() {
+			observers.forEach(observer => observer.disconnect());
+			observers.length = 0;
+			timeouts.forEach(timeout => clearTimeout(timeout));
+			timeouts.length = 0;
+			liveRegion?.remove();
+			liveRegion = null;
+		}
+
 		return {
 			onReady: [
 				upsertTimeArrows,
@@ -853,6 +877,7 @@ function customElements(pluginConfig: Config): Plugin {
 				refreshGridAfterRebuild,
 			],
 			onMonthChange: [announceMonthYear],
+			onDestroy: [cleanup],
 		};
 	};
 }

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -35,9 +35,14 @@ function customElements(pluginConfig: Config): Plugin {
 		function createLiveRegion() {
 			if (!fp?.calendarContainer) return;
 			liveRegion = document.createElement("span");
-			liveRegion.setAttribute("aria-live", "polite");
+			// Assertive: the focused-date message must interrupt/queue past NVDA's grid-context
+			// speech so the date is spoken on EVERY entry (first entry, re-entry, arrow moves).
+			// A polite region was unreliable here — it was dropped while NVDA was busy reading the
+			// grid context, so the date went unannounced on re-entry. role="alert" implies an
+			// assertive live region; the explicit aria-live keeps it unambiguous across ATs.
+			liveRegion.setAttribute("aria-live", "assertive");
 			liveRegion.setAttribute("aria-atomic", "true");
-			liveRegion.setAttribute("role", "status");
+			liveRegion.setAttribute("role", "alert");
 			liveRegion.style.position = "absolute";
 			liveRegion.style.width = "1px";
 			liveRegion.style.height = "1px";
@@ -47,14 +52,19 @@ function customElements(pluginConfig: Config): Plugin {
 			fp.calendarContainer.appendChild(liveRegion);
 		}
 
-		// Push a message into the polite live region so NVDA speaks it. Re-set even when the
-		// text is unchanged (clear first) so repeated navigation to equivalent labels still
-		// announces.
+		// Push a message into the (assertive) live region so NVDA speaks it. The clear and the set
+		// must land in SEPARATE ticks: doing both synchronously collapses to a single observed
+		// value, so re-announcing the SAME text (e.g. tabbing out of the grid and back onto the
+		// same date) would be seen as "no change" and stay silent. Emptying now and writing the
+		// message on the next tick guarantees the assistive tech observes a real transition
+		// (previous -> "" -> message) and speaks it every time, even when the text repeats.
 		function announce(message: string) {
 			if (!liveRegion || !message) return;
-			// Clearing first guarantees a DOM change is observed even if the text repeats.
 			liveRegion.textContent = "";
-			liveRegion.textContent = message;
+			const region = liveRegion;
+			setTimeout(() => {
+				region.textContent = message;
+			}, 0);
 		}
 
 		// Announce the visible month/year — used when the month/year is changed via the nav
@@ -64,16 +74,6 @@ function customElements(pluginConfig: Config): Plugin {
 			if (suppressMonthYearAnnounce) return;
 			const monthName = fp.l10n.months.longhand[fp.currentMonth];
 			announce(`${monthName} ${fp.currentYear}`);
-		}
-
-		// Announce a focused day's full spoken date (e.g. "June 23, 2026"). Driven on every
-		// day focus change. NVDA does not reliably re-announce a roving-focus gridcell on its
-		// own, so this live-region message is what the user actually hears when focus moves
-		// between dates via arrows / Home / End / PageUp / PageDown. Because the message
-		// includes the month and year, it also covers the month/year change on Page navigation.
-		function announceDay(dayElem: HTMLElement | null) {
-			const label = dayElem?.getAttribute("aria-label");
-			if (label) announce(label);
 		}
 
 		// Returns the currently "selectable" day cells of the visible month, i.e. days that
@@ -730,8 +730,8 @@ function customElements(pluginConfig: Config): Plugin {
 		// On every day-cell focus: (1) keep the roving tabindex (a single tabindex="0" day)
 		// aligned with the focused day — whether moved by flatpickr's native arrow handling or by
 		// our Home/End/Page handlers — so Tab always re-enters the grid on the right day; and
-		// (2) announce the focused date via the live region, since NVDA does not reliably speak a
-		// roving-focus gridcell on its own.
+		// (2) force NVDA to announce the focused date by toggling the focused cell's accessible
+		// name (NVDA does not reliably re-read an unchanged roving-focus gridcell on its own).
 		function syncRovingTabindex() {
 			const daysContainer =
 				fp?.calendarContainer?.querySelector<HTMLElement>(".flatpickr-days");
@@ -747,20 +747,22 @@ function customElements(pluginConfig: Config): Plugin {
 					});
 				}
 
-				// When focus enters the grid from OUTSIDE (e.g. tabbing/clicking from the
-				// next-month button), NVDA speaks the grid's own context ("Calendar, table, use
-				// arrow keys…") and drops a live-region update that lands at the same moment. Defer
-				// the date announcement one tick so it is spoken AFTER the grid context, instead of
-				// being clobbered by it. For moves WITHIN the grid (arrows/Home/End/Page) there is
-				// no competing context speech, so announce immediately.
-				const fromOutsideGrid = !(
-					event.relatedTarget instanceof HTMLElement &&
-					daysContainer.contains(event.relatedTarget)
-				);
-				if (fromOutsideGrid) {
-					setTimeout(() => announceDay(target), 50);
-				} else {
-					announceDay(target);
+				// Make NVDA speak the focused date on EVERY focus, including re-entry.
+				//
+				// The speech viewer shows NVDA reliably reads the grid context ("Calendar, table,
+				// Use arrow keys…") on every entry — that context is part of the focus event. The
+				// date is carried on the FOCUSED CELL's own accessible name; we toggle it (blank
+				// now, restore on the next tick) so NVDA sees a fresh name and re-reads the date as
+				// part of that same reliable focus path, instead of via a live region (which NVDA
+				// dropped on re-entry). We do NOT also push to the live region here — that produced
+				// a duplicate announcement of the date.
+				const dateLabel = target.getAttribute("aria-label");
+				if (dateLabel) {
+					target.setAttribute("aria-label", "");
+					setTimeout(() => {
+						// Only restore if this cell is still in the DOM (not rebuilt by a month flip).
+						if (target.isConnected) target.setAttribute("aria-label", dateLabel);
+					}, 0);
 				}
 			});
 		}

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -19,6 +19,69 @@ function customElements(pluginConfig: Config): Plugin {
 		// Store event handlers for navigation buttons
 		const navKeydownHandlers = new WeakMap<HTMLElement, (event: KeyboardEvent) => void>();
 
+		let liveRegion: HTMLElement | null = null;
+
+		function createLiveRegion() {
+			if (!fp?.calendarContainer) return;
+			liveRegion = document.createElement("span");
+			liveRegion.setAttribute("aria-live", "polite");
+			liveRegion.setAttribute("aria-atomic", "true");
+			liveRegion.setAttribute("role", "status");
+			liveRegion.style.position = "absolute";
+			liveRegion.style.width = "1px";
+			liveRegion.style.height = "1px";
+			liveRegion.style.overflow = "hidden";
+			liveRegion.style.clip = "rect(0, 0, 0, 0)";
+			liveRegion.style.whiteSpace = "nowrap";
+			fp.calendarContainer.appendChild(liveRegion);
+		}
+
+		function announceMonthYear() {
+			if (!liveRegion) return;
+			const monthName = fp.l10n.months.longhand[fp.currentMonth];
+			const year = fp.currentYear;
+			liveRegion.textContent = `${monthName} ${year}`;
+		}
+
+		function focusCurrentDay() {
+			if (!fp?.calendarContainer) return;
+			const selectedDay =
+				fp.calendarContainer.querySelector<HTMLElement>(".flatpickr-day.selected") ||
+				fp.calendarContainer.querySelector<HTMLElement>(".flatpickr-day.today") ||
+				fp.calendarContainer.querySelector<HTMLElement>(
+					".flatpickr-day:not(.flatpickr-disabled):not(.prevMonthDay):not(.nextMonthDay)",
+				);
+			if (selectedDay) {
+				const daysContainer = fp?.calendarContainer?.getElementsByClassName(
+					"flatpickr-innerContainer",
+				)[0] as HTMLElement;
+				if (daysContainer) {
+					// Use aria-activedescendant pattern for grid navigation
+					if (!selectedDay.id) {
+						selectedDay.id = `fp-day-${Math.random().toString(36).substring(2, 9)}`;
+					}
+					daysContainer.setAttribute("aria-activedescendant", selectedDay.id);
+				}
+			}
+		}
+
+		function updateDayAriaActivedescendant() {
+			if (!fp?.calendarContainer) return;
+			const daysContainer = fp?.calendarContainer?.getElementsByClassName(
+				"flatpickr-innerContainer",
+			)[0] as HTMLElement;
+			const selectedDay =
+				fp.calendarContainer.querySelector<HTMLElement>(".flatpickr-day.selected") ||
+				fp.calendarContainer.querySelector<HTMLElement>(".flatpickr-day.today");
+
+			if (daysContainer && selectedDay) {
+				if (!selectedDay.id) {
+					selectedDay.id = `fp-day-${Math.random().toString(36).substring(2, 9)}`;
+				}
+				daysContainer.setAttribute("aria-activedescendant", selectedDay.id);
+			}
+		}
+
 		function buildTimeArrows() {
 			if (!fp?.config?.enableTime) return;
 			const arrowUp = fp?.timeContainer?.getElementsByClassName("arrowUp");
@@ -176,7 +239,30 @@ function customElements(pluginConfig: Config): Plugin {
 			)[0];
 			if (daysContainer) {
 				daysContainer.setAttribute("tabindex", "0");
+				daysContainer.setAttribute("role", "grid");
+				daysContainer.setAttribute(
+					"aria-label",
+					customTranslations?.ariaLabels?.datePickerGridLabel || "Calendar",
+				);
+				daysContainer.setAttribute(
+					"aria-description",
+					customTranslations?.ariaLabels?.datePickerGridDescription ||
+						"Use arrow keys to navigate through dates",
+				);
 			}
+
+			const weekdayContainer =
+				fp?.calendarContainer?.querySelector(".flatpickr-weekdays");
+			if (weekdayContainer) {
+				weekdayContainer.setAttribute("role", "row");
+			}
+			const weekdaySpans = fp?.calendarContainer?.querySelectorAll(
+				".flatpickr-weekday",
+			);
+			weekdaySpans?.forEach(span => {
+				span.setAttribute("role", "columnheader");
+				span.setAttribute("abbr", span.textContent?.trim() || "");
+			});
 		}
 
 		// Observe month selector for changes and set tabindex again to 0. This is to ensure that the month selector is focusable all the time
@@ -303,6 +389,65 @@ function customElements(pluginConfig: Config): Plugin {
 			}
 		}
 
+		// Handle arrow key navigation for grid using aria-activedescendant
+		function setGridArrowKeyNavigation() {
+			const daysContainer = fp?.calendarContainer?.getElementsByClassName(
+				"flatpickr-innerContainer",
+			)[0] as HTMLElement;
+
+			if (!daysContainer) return;
+
+			daysContainer.addEventListener("keydown", (event: KeyboardEvent) => {
+				if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(event.key)) {
+					return;
+				}
+
+				event.preventDefault();
+
+				const allDays = Array.from(
+					fp?.calendarContainer?.querySelectorAll<HTMLElement>(".flatpickr-day") || [],
+				);
+				const activeDayId = daysContainer.getAttribute("aria-activedescendant");
+				const currentDay = activeDayId
+					? fp?.calendarContainer?.querySelector(`#${activeDayId}`)
+					: null;
+				const currentIndex = currentDay ? allDays.indexOf(currentDay as HTMLElement) : -1;
+
+				let nextIndex = currentIndex;
+
+				// Get grid dimensions (7 columns for days of week)
+				const cols = 7;
+
+				switch (event.key) {
+					case "ArrowDown":
+						nextIndex = currentIndex + cols;
+						break;
+					case "ArrowUp":
+						nextIndex = currentIndex - cols;
+						break;
+					case "ArrowRight":
+						nextIndex = currentIndex + 1;
+						break;
+					case "ArrowLeft":
+						nextIndex = currentIndex - 1;
+						break;
+				}
+
+				// Clamp to valid range
+				if (nextIndex >= 0 && nextIndex < allDays.length) {
+					const nextDay = allDays[nextIndex];
+					if (!nextDay.classList.contains("flatpickr-disabled")) {
+						if (!nextDay.id) {
+							nextDay.id = `fp-day-${Math.random().toString(36).substring(2, 9)}`;
+						}
+						daysContainer.setAttribute("aria-activedescendant", nextDay.id);
+						// Announce the date via live region
+						announceMonthYear();
+					}
+				}
+			});
+		}
+
 		return {
 			onReady: [
 				upsertTimeArrows,
@@ -314,11 +459,16 @@ function customElements(pluginConfig: Config): Plugin {
 				setNavButtonsAlly,
 				observeNavButtons,
 				observeMonthSelector,
+				createLiveRegion,
+				focusCurrentDay,
+				setGridArrowKeyNavigation,
 
 				() => {
 					fp?.loadedPlugins?.push("customElements");
 				},
 			],
+			onMonthChange: [announceMonthYear],
+			onYearChange: [announceMonthYear],
 			onDayCreate: [
 				(_dObj, _dStr, _fp, dayElem) => {
 					// Set aria-disabled attribute based on flatpickr-disabled class
@@ -330,10 +480,31 @@ function customElements(pluginConfig: Config): Plugin {
 					}
 
 					dayElem.innerHTML = `<span class='dayInner'>${dayElem.innerHTML}</span>`;
+					// All day cells are not focusable by default (using aria-activedescendant pattern)
+					dayElem.setAttribute("tabindex", "-1");
+					// Use presentation role so individual dates don't announce as clickable items
+					dayElem.setAttribute("role", "presentation");
+					// Ensure each date has a unique ID for aria-activedescendant
+					if (!dayElem.id) {
+						dayElem.id = `fp-day-${Math.random().toString(36).substring(2, 9)}`;
+					}
+					// Add aria-label with full date so screen reader announces "June 1" when navigated
+					const dateNum = dayElem.textContent?.trim();
+					if (dateNum && !isDisabled) {
+						const monthName = fp.l10n.months.longhand[fp.currentMonth];
+						dayElem.setAttribute("aria-label", `${monthName} ${dateNum}, ${fp.currentYear}`);
+					}
 				},
 				handleWeekNumbers,
 			],
-			onValueUpdate: [upsertTimeArrows],
+			onValueUpdate: [upsertTimeArrows, updateDayAriaActivedescendant],
+			onMonthChange: [
+				announceMonthYear,
+				() => {
+					// Re-attach arrow key navigation when month changes
+					setGridArrowKeyNavigation();
+				},
+			],
 		};
 	};
 }

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -498,19 +498,28 @@ function customElements(pluginConfig: Config): Plugin {
 			return (cell as unknown as { dateObj?: Date }).dateObj;
 		}
 
+		function sameYMD(a: Date | undefined, b: Date): boolean {
+			return (
+				!!a &&
+				a.getFullYear() === b.getFullYear() &&
+				a.getMonth() === b.getMonth() &&
+				a.getDate() === b.getDate()
+			);
+		}
+
 		// Find the IN-MONTH cell for a given Y/M/D in the currently visible grid, if present
 		// (ignores prev/next-month overflow cells so we match the canonical cell for that date).
 		function findInMonthCellByDate(date: Date): HTMLElement | null {
+			return getInMonthCells().find(c => sameYMD(cellDate(c), date)) || null;
+		}
+
+		// Find ANY cell (including prev/next-month overflow cells) for a given Y/M/D in the
+		// currently visible grid. Preference is still given to the canonical in-month cell.
+		function findAnyCellByDate(date: Date): HTMLElement | null {
 			return (
-				getInMonthCells().find(c => {
-					const d = cellDate(c);
-					return (
-						!!d &&
-						d.getFullYear() === date.getFullYear() &&
-						d.getMonth() === date.getMonth() &&
-						d.getDate() === date.getDate()
-					);
-				}) || null
+				findInMonthCellByDate(date) ||
+				getDayCells().find(c => sameYMD(cellDate(c), date)) ||
+				null
 			);
 		}
 
@@ -608,6 +617,10 @@ function customElements(pluginConfig: Config): Plugin {
 						// does not select, so handle both here and stop flatpickr double-acting.
 						event.preventDefault();
 						event.stopPropagation();
+						// Select the focused day by dispatching a click — this routes through the
+						// same day-click path as the mouse, so the click capture listener below marks
+						// the selection and suppresses flatpickr's hour-focus jump uniformly for both
+						// keyboard and mouse. onValueUpdate then keeps focus on the selected day.
 						currentDay.click();
 						return;
 					}
@@ -664,6 +677,54 @@ function customElements(pluginConfig: Config): Plugin {
 					}
 				}
 			});
+
+			// Selecting a day fires a click on the day cell — for the mouse directly, and for the
+			// keyboard via currentDay.click() in the Enter/Space handler above. flatpickr binds its
+			// selectDate to the days container (bubble phase). At the end of selectDate it
+			// force-moves focus: to the time picker's hour field when a time picker exists, or to
+			// the just-clicked day element otherwise (but that element is detached by the preceding
+			// buildDays() rebuild, so focus actually drops to <body>). Either way the user is pulled
+			// out of the grid, and the hour case causes a focus flash the screen reader announces.
+			//
+			// In the CAPTURE phase here (before flatpickr's bubble-phase selectDate runs) we
+			// neutralize the hour field's .focus() so flatpickr can't focus it at all — that
+			// removes the focus flash the screen reader would otherwise announce. Then, on the next
+			// microtask — after selectDate has fully run, including its own focus calls — we place
+			// focus on the just-selected day in the rebuilt grid. This keeps the user in the grid
+			// for single/range/multiple selection, with or without a time picker. The hour focus
+			// override is restored in the same microtask (guarded so re-entrant clicks never
+			// capture an already-neutralized focus and leave the field unfocusable).
+			let hourFocusSuppressed = false;
+			daysContainer.addEventListener(
+				"click",
+				(event: MouseEvent) => {
+					const cell = (event.target as HTMLElement)?.closest?.(".flatpickr-day");
+					if (!cell || cell.classList.contains("flatpickr-disabled")) return;
+
+					const hour = fp?.hourElement;
+					let restoreHourFocus: (() => void) | null = null;
+					if (hour && !hourFocusSuppressed) {
+						hourFocusSuppressed = true;
+						const originalFocus = hour.focus.bind(hour);
+						hour.focus = () => {};
+						restoreHourFocus = () => {
+							hour.focus = originalFocus;
+							hourFocusSuppressed = false;
+						};
+					}
+
+					Promise.resolve().then(() => {
+						restoreHourFocus?.();
+						// Dialog may have closed (e.g. Confirm clicked); don't focus a detached grid.
+						if (!fp?.calendarContainer?.isConnected) return;
+						// Read the selected date now — selectDate has run and updated it by this point.
+						const selectedDate = fp.latestSelectedDateObj;
+						const justSelected = selectedDate && findAnyCellByDate(selectedDate);
+						setActiveDay(justSelected || getInitialActiveDay(), { focus: true });
+					});
+				},
+				true,
+			);
 		}
 
 		// On every day-cell focus: (1) keep the roving tabindex (a single tabindex="0" day)
@@ -771,14 +832,11 @@ function customElements(pluginConfig: Config): Plugin {
 			onValueUpdate: [
 				upsertTimeArrows,
 				// Selecting a date rebuilds the day grid synchronously (flatpickr calls
-				// buildDays() before firing onValueUpdate). Re-apply the grid indices and restore
-				// a single focusable day so the roving-tabindex invariant survives selection, and
-				// mark the newly selected gridcell.
+				// buildDays() before firing onValueUpdate). Re-apply the grid indices, mark the
+				// selected gridcell(s), and keep the roving tabindex pointed at a valid day.
 				() => {
 					applyDayGridIndices();
-					const selected = fp?.calendarContainer?.querySelector<HTMLElement>(
-						".dayContainer .flatpickr-day.selected",
-					);
+
 					getDayCells().forEach(day => {
 						if (day.classList.contains("selected")) {
 							day.setAttribute("aria-selected", "true");
@@ -786,7 +844,16 @@ function customElements(pluginConfig: Config): Plugin {
 							day.removeAttribute("aria-selected");
 						}
 					});
-					setActiveDay(selected || getInitialActiveDay(), { focus: false });
+
+					// Keep the roving tabindex pointed at a valid day WITHOUT moving focus here.
+					// For a date selection, flatpickr force-moves focus AFTER this hook (to the time
+					// picker, or to a now-detached day -> <body>); that is handled by the click
+					// capture listener's microtask, which places focus on the just-selected day once
+					// selectDate has fully run. Moving focus here would be overwritten by flatpickr.
+					const existing = fp?.calendarContainer?.querySelector<HTMLElement>(
+						".dayContainer .flatpickr-day[tabindex='0']",
+					);
+					setActiveDay(existing || getInitialActiveDay(), { focus: false });
 				},
 			],
 			onMonthChange: [announceMonthYear],

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -8,18 +8,21 @@ export interface Config {
 }
 
 /**
- * Custom flatpickr plugin that adds some DOM elements for webchat v3 design
- * It handles timeContainer, weekNumbers, and custom accessibility logic for some datepicker elements.
+ * Custom flatpickr plugin for the webchat v3 datepicker. It builds the timeContainer and
+ * weekNumbers DOM and layers accessibility on top of flatpickr's calendar.
  *
  * The calendar grid follows the W3C ARIA APG "Date Picker Dialog" pattern:
- * - `.flatpickr-rContainer` is the `role="grid"` (it wraps the weekday header row and the day rows)
+ * - `.flatpickr-rContainer` is the `role="grid"` (wraps the weekday header row and the day grid)
  * - the weekday header is a `role="row"` of `role="columnheader"` cells
- * - the day cells are `role="gridcell"`, grouped 7-per-`role="row"`
- * - focus is managed with a roving tabindex: exactly one day is `tabindex="0"`, the rest `-1`
- * - arrow keys / Home / End / PageUp / PageDown move real DOM focus between days
+ * - day cells are flat `role="gridcell"` elements with `aria-rowindex`/`aria-colindex` (NOT
+ *   physical `role="row"` wrappers, which would break flatpickr's native arrow navigation that
+ *   indexes the day cells as direct children of `.dayContainer`)
+ * - focus uses a roving tabindex: exactly one day is `tabindex="0"`, the rest `-1`
+ * - flatpickr owns in-month arrow navigation; this plugin adds Home/End, PageUp/PageDown, and
+ *   sequential cross-month arrow movement, and announces the focused date to screen readers
  */
 function customElements(pluginConfig: Config): Plugin {
-	// fp`refers to the Flatpickr instance
+	// `fp` is the Flatpickr instance.
 	return function (fp: Instance) {
 		const { arrowIcon, customTranslations } = pluginConfig;
 
@@ -333,32 +336,49 @@ function customElements(pluginConfig: Config): Plugin {
 			});
 		}
 
-		// Re-apply grid row roles and restore the single focusable day whenever flatpickr
-		// rebuilds the day grid (default-date application, redraws, month/year changes).
-		// A MutationObserver on the stable `.flatpickr-days` container is the most robust hook,
-		// matching the defensive pattern used for the nav buttons and month selector.
+		// Mark the currently selected day cell(s) with aria-selected for assistive tech.
+		function markSelectedCells() {
+			getDayCells().forEach(day => {
+				if (day.classList.contains("selected")) {
+					day.setAttribute("aria-selected", "true");
+				} else {
+					day.removeAttribute("aria-selected");
+				}
+			});
+		}
+
+		// Keep exactly one focusable day after a rebuild, WITHOUT moving focus: preserve the
+		// existing roving target if it survived, else fall back to the selected/today/first day.
+		function restoreRovingDay() {
+			const existing = fp?.calendarContainer?.querySelector<HTMLElement>(
+				".dayContainer .flatpickr-day[tabindex='0']",
+			);
+			setActiveDay(existing || getInitialActiveDay(), { focus: false });
+		}
+
+		// After flatpickr rebuilds the day grid: refresh row/column indices, selection state, and
+		// the roving tabindex. Used by both the MutationObserver and the onValueUpdate hook.
+		function refreshGridAfterRebuild() {
+			applyDayGridIndices();
+			markSelectedCells();
+			restoreRovingDay();
+		}
+
+		// flatpickr replaces `.dayContainer` on every render (default-date application, redraws,
+		// month/year changes). Observe the stable `.flatpickr-days` container and refresh after
+		// each rebuild — the same defensive pattern used for the nav buttons and month selector.
 		function observeDayGrid() {
 			const daysContainer =
 				fp?.calendarContainer?.querySelector<HTMLElement>(".flatpickr-days");
 			if (!daysContainer || daysContainer.dataset.gridObserved === "true") return;
 			daysContainer.dataset.gridObserved = "true";
 
-			const reapply = () => {
-				applyDayGridIndices();
-				// Keep exactly one focusable day. Preserve the existing roving target if it is
-				// still in the DOM; otherwise fall back to the selected/today/first day.
-				const existing = daysContainer.querySelector<HTMLElement>(
-					".flatpickr-day[tabindex='0']",
-				);
-				setActiveDay(existing || getInitialActiveDay(), { focus: false });
-			};
-
-			// `.dayContainer` is replaced on every flatpickr render; re-apply on each childList
-			// change. We only set attributes (not move nodes), so this never re-triggers itself.
-			const observer = new MutationObserver(() => reapply());
+			// The refresh only sets attributes (never moves nodes), so it never re-triggers the
+			// observer's childList watch.
+			const observer = new MutationObserver(() => refreshGridAfterRebuild());
 			observer.observe(daysContainer, { childList: true, subtree: true });
 			// Apply once immediately for the initial render.
-			reapply();
+			refreshGridAfterRebuild();
 		}
 
 		// Observe month selector for changes and set tabindex again to 0. This is to ensure that the month selector is focusable all the time
@@ -496,6 +516,12 @@ function customElements(pluginConfig: Config): Plugin {
 		// Read the real Date for a day cell (flatpickr stores it on dateObj).
 		function cellDate(cell: HTMLElement): Date | undefined {
 			return (cell as unknown as { dateObj?: Date }).dateObj;
+		}
+
+		// Spoken date label for a cell, e.g. "June 1, 2026". Uses the cell's own date so
+		// prev/next-month overflow cells announce their real month (not the visible month).
+		function getDayLabel(date: Date): string {
+			return `${fp.l10n.months.longhand[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
 		}
 
 		function sameYMD(a: Date | undefined, b: Date): boolean {
@@ -813,50 +839,20 @@ function customElements(pluginConfig: Config): Plugin {
 					} else {
 						dayElem.removeAttribute("aria-selected");
 					}
-					// Ensure each date has a unique ID (used by tests / potential labelling).
-					if (!dayElem.id) {
-						dayElem.id = `fp-day-${Math.random().toString(36).substring(2, 9)}`;
-					}
-					// Spoken aria-label so the screen reader announces e.g. "June 1, 2026" when the
-					// day is focused. Use the cell's own date (dayElem.dateObj) rather than the
-					// visible month, so prev/next-month days announce their real month — not "June 31".
-					const cellDate = (dayElem as unknown as { dateObj?: Date }).dateObj;
-					if (cellDate) {
-						const monthName = fp.l10n.months.longhand[cellDate.getMonth()];
-						dayElem.setAttribute(
-							"aria-label",
-							`${monthName} ${cellDate.getDate()}, ${cellDate.getFullYear()}`,
-						);
-					}
+					// Spoken aria-label so the screen reader announces e.g. "June 1, 2026" on focus.
+					const date = cellDate(dayElem);
+					if (date) dayElem.setAttribute("aria-label", getDayLabel(date));
 				},
 				handleWeekNumbers,
 			],
 			onValueUpdate: [
 				upsertTimeArrows,
-				// Selecting a date rebuilds the day grid synchronously (flatpickr calls
-				// buildDays() before firing onValueUpdate). Re-apply the grid indices, mark the
-				// selected gridcell(s), and keep the roving tabindex pointed at a valid day.
-				() => {
-					applyDayGridIndices();
-
-					getDayCells().forEach(day => {
-						if (day.classList.contains("selected")) {
-							day.setAttribute("aria-selected", "true");
-						} else {
-							day.removeAttribute("aria-selected");
-						}
-					});
-
-					// Keep the roving tabindex pointed at a valid day WITHOUT moving focus here.
-					// For a date selection, flatpickr force-moves focus AFTER this hook (to the time
-					// picker, or to a now-detached day -> <body>); that is handled by the click
-					// capture listener's microtask, which places focus on the just-selected day once
-					// selectDate has fully run. Moving focus here would be overwritten by flatpickr.
-					const existing = fp?.calendarContainer?.querySelector<HTMLElement>(
-						".dayContainer .flatpickr-day[tabindex='0']",
-					);
-					setActiveDay(existing || getInitialActiveDay(), { focus: false });
-				},
+				// Selecting a date rebuilds the day grid synchronously (flatpickr calls buildDays()
+				// before firing onValueUpdate), so refresh indices/selection/roving tabindex.
+				// We do NOT move focus here: flatpickr force-moves focus AFTER this hook (to the
+				// time picker, or to a now-detached day -> <body>); the click-capture listener's
+				// microtask places focus on the just-selected day once selectDate has fully run.
+				refreshGridAfterRebuild,
 			],
 			onMonthChange: [announceMonthYear],
 		};

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -83,8 +83,9 @@ function customElements(pluginConfig: Config): Plugin {
 		// belong to the current month and are not disabled. Used for roving-focus targets.
 		function getDayCells(): HTMLElement[] {
 			return Array.from(
-				fp?.calendarContainer?.querySelectorAll<HTMLElement>(".dayContainer .flatpickr-day") ||
-					[],
+				fp?.calendarContainer?.querySelectorAll<HTMLElement>(
+					".dayContainer .flatpickr-day",
+				) || [],
 			);
 		}
 
@@ -320,8 +321,7 @@ function customElements(pluginConfig: Config): Plugin {
 		// native arrow navigation). The `.dayContainer` is the rowgroup. Flatpickr rebuilds
 		// `.dayContainer` on every render, so this must run after each rebuild.
 		function applyDayGridIndices() {
-			const dayContainer =
-				fp?.calendarContainer?.querySelector<HTMLElement>(".dayContainer");
+			const dayContainer = fp?.calendarContainer?.querySelector<HTMLElement>(".dayContainer");
 			if (!dayContainer) return;
 
 			dayContainer.setAttribute("role", "rowgroup");
@@ -508,8 +508,7 @@ function customElements(pluginConfig: Config): Plugin {
 		// In-month day cells of the visible month (excludes prev/next-month overflow cells).
 		function getInMonthCells(): HTMLElement[] {
 			return getDayCells().filter(
-				c =>
-					!c.classList.contains("prevMonthDay") && !c.classList.contains("nextMonthDay"),
+				c => !c.classList.contains("prevMonthDay") && !c.classList.contains("nextMonthDay"),
 			);
 		}
 
@@ -598,8 +597,7 @@ function customElements(pluginConfig: Config): Plugin {
 						const idx = cells.indexOf(currentDay);
 						if (idx === -1) return;
 						const weekStart = idx - (idx % cols);
-						const targetIdx =
-							event.key === "Home" ? weekStart : weekStart + (cols - 1);
+						const targetIdx = event.key === "Home" ? weekStart : weekStart + (cols - 1);
 						const target = cells[targetIdx];
 						if (target && !target.classList.contains("flatpickr-disabled")) {
 							setActiveDay(target, { focus: true });
@@ -667,10 +665,10 @@ function customElements(pluginConfig: Config): Plugin {
 							event.key === "ArrowRight"
 								? 1
 								: event.key === "ArrowLeft"
-								? -1
-								: event.key === "ArrowDown"
-								? cols
-								: -cols;
+									? -1
+									: event.key === "ArrowDown"
+										? cols
+										: -cols;
 						const targetDate = new Date(from);
 						targetDate.setDate(targetDate.getDate() + deltaDays);
 

--- a/src/messages/DatePicker/flatpickr-plugins/customElements.ts
+++ b/src/messages/DatePicker/flatpickr-plugins/customElements.ts
@@ -493,6 +493,27 @@ function customElements(pluginConfig: Config): Plugin {
 			);
 		}
 
+		// Read the real Date for a day cell (flatpickr stores it on dateObj).
+		function cellDate(cell: HTMLElement): Date | undefined {
+			return (cell as unknown as { dateObj?: Date }).dateObj;
+		}
+
+		// Find the IN-MONTH cell for a given Y/M/D in the currently visible grid, if present
+		// (ignores prev/next-month overflow cells so we match the canonical cell for that date).
+		function findInMonthCellByDate(date: Date): HTMLElement | null {
+			return (
+				getInMonthCells().find(c => {
+					const d = cellDate(c);
+					return (
+						!!d &&
+						d.getFullYear() === date.getFullYear() &&
+						d.getMonth() === date.getMonth() &&
+						d.getDate() === date.getDate()
+					);
+				}) || null
+			);
+		}
+
 		// After a month/year change, move roving focus to the day with the same day-of-month
 		// number (APG PageUp/PageDown behavior). If that day does not exist in the new month
 		// (e.g. Jan 31 -> Feb), focus the last day of the month instead.
@@ -509,14 +530,16 @@ function customElements(pluginConfig: Config): Plugin {
 
 		// Keyboard navigation for the calendar grid.
 		//
-		// IMPORTANT: flatpickr already implements Arrow-key navigation natively (focusOnDay /
-		// getNextAvailableDay), including disabled-day skipping and crossing month boundaries.
-		// We deliberately do NOT handle Arrow keys here — doing so previously ran two handlers in
-		// parallel that fought over focus (each arrow moved focus twice, and focus was lost after
-		// a month change). Instead we let flatpickr own the arrows and only add the keys it lacks:
-		// Home / End (within the week) and PageUp / PageDown (prev/next month, same day number).
-		// A separate `focusin` listener (see syncRovingTabindex) keeps the roving tabindex aligned
-		// with whatever day flatpickr focuses, so Tab can always re-enter the grid.
+		// IMPORTANT: flatpickr implements Arrow-key navigation natively (focusOnDay /
+		// getNextAvailableDay), including disabled-day skipping. We let flatpickr own arrow moves
+		// that stay WITHIN the visible month — handling them ourselves previously ran two handlers
+		// in parallel that fought over focus. We only take over an arrow when the move crosses a
+		// month boundary, because flatpickr there jumps to the "first available day" of the new
+		// grid (non-sequential, confusing for screen-reader users) instead of the sequential
+		// next/previous calendar day. We also add the keys flatpickr lacks: Home / End (within the
+		// week) and PageUp / PageDown (prev/next month, same day number). A separate `focusin`
+		// listener (see syncRovingTabindex) keeps the roving tabindex aligned with whatever day is
+		// focused, so Tab can always re-enter the grid.
 		function setGridKeyNavigation() {
 			const daysContainer =
 				fp?.calendarContainer?.querySelector<HTMLElement>(".flatpickr-days");
@@ -588,7 +611,57 @@ function customElements(pluginConfig: Config): Plugin {
 						currentDay.click();
 						return;
 					}
-					// Arrow keys intentionally fall through to flatpickr's native handler.
+					case "ArrowLeft":
+					case "ArrowRight":
+					case "ArrowUp":
+					case "ArrowDown": {
+						// Within the visible month, flatpickr's native arrow navigation is correct,
+						// so we let it handle the move (fall through). We ONLY take over when the
+						// move would cross a month boundary: flatpickr's cross-month behavior jumps
+						// to the "first available day" of the new grid (e.g. ArrowRight on July 11 ->
+						// June 28), which is non-sequential and confusing for screen-reader users.
+						// Instead we move to the SEQUENTIAL next/previous calendar day.
+						const from = cellDate(currentDay);
+						if (!from) return; // no date info -> leave it to flatpickr
+
+						const deltaDays =
+							event.key === "ArrowRight"
+								? 1
+								: event.key === "ArrowLeft"
+								? -1
+								: event.key === "ArrowDown"
+								? cols
+								: -cols;
+						const targetDate = new Date(from);
+						targetDate.setDate(targetDate.getDate() + deltaDays);
+
+						// If the sequential target is an in-month cell already in this grid, let
+						// flatpickr move focus there natively (no interception).
+						if (findInMonthCellByDate(targetDate)) return;
+
+						// Otherwise the target lives in the adjacent month: flip the calendar and
+						// land focus on that exact date (sequential), announced via focusin.
+						event.preventDefault();
+						event.stopPropagation();
+						suppressMonthYearAnnounce = true;
+						fp.changeMonth(deltaDays > 0 ? 1 : -1);
+						suppressMonthYearAnnounce = false;
+
+						const exact = findInMonthCellByDate(targetDate);
+						if (exact && !exact.classList.contains("flatpickr-disabled")) {
+							setActiveDay(exact, { focus: true });
+						} else {
+							// Exact date missing/disabled (rare, e.g. min/max bounds): fall back to
+							// the nearest enabled in-month day in the direction of travel.
+							const inMonth = getInMonthCells().filter(
+								c => !c.classList.contains("flatpickr-disabled"),
+							);
+							const fallback =
+								deltaDays > 0 ? inMonth[0] : inMonth[inMonth.length - 1];
+							setActiveDay(fallback || getInitialActiveDay(), { focus: true });
+						}
+						return;
+					}
 				}
 			});
 		}
@@ -612,7 +685,22 @@ function customElements(pluginConfig: Config): Plugin {
 						day.setAttribute("tabindex", day === target ? "0" : "-1");
 					});
 				}
-				announceDay(target);
+
+				// When focus enters the grid from OUTSIDE (e.g. tabbing/clicking from the
+				// next-month button), NVDA speaks the grid's own context ("Calendar, table, use
+				// arrow keys…") and drops a live-region update that lands at the same moment. Defer
+				// the date announcement one tick so it is spoken AFTER the grid context, instead of
+				// being clobbered by it. For moves WITHIN the grid (arrows/Home/End/Page) there is
+				// no competing context speech, so announce immediately.
+				const fromOutsideGrid = !(
+					event.relatedTarget instanceof HTMLElement &&
+					daysContainer.contains(event.relatedTarget)
+				);
+				if (fromOutsideGrid) {
+					setTimeout(() => announceDay(target), 50);
+				} else {
+					announceDay(target);
+				}
 			});
 		}
 

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -160,6 +160,8 @@ export interface IWebchatSettings {
 			closeFullsizeImageModal?: string;
 			datePickerPreviousMonth?: string;
 			datePickerNextMonth?: string;
+			datePickerGridLabel?: string;
+			datePickerGridDescription?: string;
 			actionButtonPositionText?: string;
 			buttonGroupLabel?: string;
 			slidesCountText?: string;

--- a/test/Datepicker.spec.tsx
+++ b/test/Datepicker.spec.tsx
@@ -181,7 +181,10 @@ describe("Message Datepicker", () => {
 		await waitFor(() => expect(isFocusedDay()).toBe(true));
 
 		// Move and make the second pick.
-		fireEvent.keyDown(document.activeElement as HTMLElement, { key: "ArrowRight", keyCode: 39 });
+		fireEvent.keyDown(document.activeElement as HTMLElement, {
+			key: "ArrowRight",
+			keyCode: 39,
+		});
 		fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Enter", keyCode: 13 });
 		await waitFor(() => expect(isFocusedDay()).toBe(true));
 

--- a/test/Datepicker.spec.tsx
+++ b/test/Datepicker.spec.tsx
@@ -1,14 +1,31 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import singleDate from "test/fixtures/datepicker/singleDate.json";
 import noTime from "test/fixtures/datepicker/noTime.json";
+import range from "test/fixtures/datepicker/range.json";
 import { IMessage } from "@cognigy/socket-client";
 import moment from "moment";
+
+// The single roving-focus day cell (tabindex="0").
+const activeDay = (root: HTMLElement) =>
+	root.querySelector<HTMLElement>('.dayContainer .flatpickr-day[tabindex="0"]');
+const isFocusedDay = () =>
+	(document.activeElement as HTMLElement)?.classList?.contains("flatpickr-day");
+
+const openDialog = async (
+	findByRole: (role: string) => Promise<HTMLElement>,
+	getByTestId: (id: string) => HTMLElement,
+) => {
+	fireEvent.click(getByTestId("button-open"));
+	await findByRole("dialog");
+	return screen.getByTestId("datepicker-message");
+};
 
 describe("Message Datepicker", () => {
 	const messageSingleDate = singleDate as unknown as IMessage;
 	const messageNoTime = noTime as unknown as IMessage;
+	const messageRange = range as unknown as IMessage;
 
 	it("renders datepicker message", async () => {
 		const { getByTestId } = render(<Message message={messageSingleDate} />);
@@ -54,13 +71,14 @@ describe("Message Datepicker", () => {
 		const input = screen.getByTestId("datepicker-message").querySelector(".flatpickr-input");
 		expect(input).toHaveValue("");
 
-		// click today cell in calendar
-		const today = moment().locale("en").format("MM/DD/YYYY");
-		const todayCell = getByLabelText(`${today} 12:00 AM`);
+		// click today cell in calendar (day cells use a spoken date label, e.g. "June 23, 2026")
+		const todaySpoken = moment().locale("en").format("MMMM D, YYYY");
+		const todayCell = getByLabelText(todaySpoken);
 		expect(todayCell).toBeInTheDocument();
 		fireEvent.click(todayCell);
 
 		// today date is now selected
+		const today = moment().locale("en").format("MM/DD/YYYY");
 		expect(input).toHaveValue(`${today} 12:30 PM`);
 
 		// interact time inputs
@@ -97,10 +115,11 @@ describe("Message Datepicker", () => {
 			.querySelector(".flatpickr-time");
 		expect(timeContainer).not.toBeInTheDocument();
 
-		// tomorrow date is selected by default
-		const tomorrow = moment().add(1, "days").locale("en").format("MM/DD/YYYY");
-		const tomorrowCell = getByLabelText(tomorrow);
+		// tomorrow date is selected by default (day cells use a spoken date label)
+		const tomorrowSpoken = moment().add(1, "days").locale("en").format("MMMM D, YYYY");
+		const tomorrowCell = getByLabelText(tomorrowSpoken);
 		expect(tomorrowCell).toHaveClass("selected");
+		const tomorrow = moment().add(1, "days").locale("en").format("MM/DD/YYYY");
 		const input = screen.getByTestId("datepicker-message").querySelector(".flatpickr-input");
 		expect(input).toHaveValue(tomorrow);
 
@@ -116,5 +135,86 @@ describe("Message Datepicker", () => {
 
 		// dialog closed
 		expect(queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("keeps focus on the selected day (not the time picker) when selecting via keyboard", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		activeDay(root)!.focus();
+		fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Enter", keyCode: 13 });
+
+		// flatpickr would jump focus to the hour field after selecting; we keep it on the day.
+		await waitFor(() => expect(isFocusedDay()).toBe(true));
+		expect((document.activeElement as HTMLElement).classList.contains("flatpickr-hour")).toBe(
+			false,
+		);
+
+		// The time field is still reachable afterwards (focus override was restored).
+		const hour = root.querySelector(".flatpickr-hour") as HTMLInputElement;
+		hour.focus();
+		expect(document.activeElement).toBe(hour);
+	});
+
+	it("keeps focus on the selected day (not the time picker) when selecting via mouse", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		const cell = root.querySelector<HTMLElement>(
+			".dayContainer .flatpickr-day:not(.flatpickr-disabled):not(.prevMonthDay):not(.nextMonthDay)",
+		)!;
+		fireEvent.click(cell);
+
+		await waitFor(() => expect(isFocusedDay()).toBe(true));
+		expect((document.activeElement as HTMLElement).classList.contains("flatpickr-hour")).toBe(
+			false,
+		);
+	});
+
+	it("keeps focus on the day across both range picks", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageRange} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		// First pick.
+		activeDay(root)!.focus();
+		fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Enter", keyCode: 13 });
+		await waitFor(() => expect(isFocusedDay()).toBe(true));
+
+		// Move and make the second pick.
+		fireEvent.keyDown(document.activeElement as HTMLElement, { key: "ArrowRight", keyCode: 39 });
+		fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Enter", keyCode: 13 });
+		await waitFor(() => expect(isFocusedDay()).toBe(true));
+
+		expect(getByTestId("button-submit")).toBeEnabled();
+	});
+
+	it("keeps focus on the day when selecting in a no-time picker (no <body> drop)", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageNoTime} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		activeDay(root)!.focus();
+		fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Enter", keyCode: 13 });
+
+		await waitFor(() => expect(isFocusedDay()).toBe(true));
+		expect(document.activeElement).not.toBe(document.body);
+	});
+
+	it("changing the time does not pull focus back into the calendar grid", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		// Select a day, then move to the time field and change the time.
+		activeDay(root)!.focus();
+		fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Enter", keyCode: 13 });
+		await waitFor(() => expect(isFocusedDay()).toBe(true));
+
+		const hour = root.querySelector(".flatpickr-hour") as HTMLInputElement;
+		hour.focus();
+		fireEvent.click(root.querySelector(".flatpickr-time .arrowDown") as Element);
+
+		// Focus stays in the time area; it is NOT yanked back to a day cell.
+		await new Promise(resolve => setTimeout(resolve, 0));
+		expect((document.activeElement as HTMLElement).closest(".flatpickr-time")).not.toBeNull();
+		expect(isFocusedDay()).toBe(false);
 	});
 });

--- a/test/DatepickerA11y.spec.tsx
+++ b/test/DatepickerA11y.spec.tsx
@@ -1,117 +1,372 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import singleDate from "test/fixtures/datepicker/singleDate.json";
 import { IMessage } from "@cognigy/socket-client";
 
-describe("DatePicker Accessibility (Issues A, B, C, E)", () => {
+const openDialog = async (
+	findByRole: (role: string) => Promise<HTMLElement>,
+	getByTestId: (id: string) => HTMLElement,
+) => {
+	fireEvent.click(getByTestId("button-open"));
+	await findByRole("dialog");
+	return screen.getByTestId("datepicker-message");
+};
+
+// The single roving-focus day cell (tabindex="0").
+const activeDay = (root: HTMLElement) =>
+	root.querySelector<HTMLElement>('.flatpickr-day[tabindex="0"]');
+
+// In-grid day cells of the visible month grid (the 42 cells inside .dayContainer).
+const getDayCells = (root: HTMLElement) =>
+	Array.from(root.querySelectorAll<HTMLElement>(".dayContainer .flatpickr-day"));
+
+// flatpickr stores the real Date for each day cell on `dateObj`.
+const dateOf = (cell: Element | null) =>
+	(cell as unknown as { dateObj?: Date } | null)?.dateObj;
+
+// Dispatch a keydown carrying a real keyCode. Flatpickr's native arrow navigation reads
+// e.keyCode, so arrow tests must set it (Testing Library's keyDown leaves keyCode at 0).
+const KEY_CODES: Record<string, number> = {
+	Tab: 9,
+	Enter: 13,
+	End: 35,
+	Home: 36,
+	ArrowLeft: 37,
+	ArrowUp: 38,
+	ArrowRight: 39,
+	ArrowDown: 40,
+	PageUp: 33,
+	PageDown: 34,
+};
+const pressKey = (key: string, shiftKey = false) => {
+	const el = document.activeElement as HTMLElement;
+	el.dispatchEvent(
+		new KeyboardEvent("keydown", {
+			key,
+			keyCode: KEY_CODES[key],
+			shiftKey,
+			bubbles: true,
+			cancelable: true,
+		} as KeyboardEventInit),
+	);
+};
+const focusedLabel = () => (document.activeElement as HTMLElement)?.getAttribute("aria-label");
+
+// The suite runs on real timers, and several accessibility behaviors are async:
+//  - the focused cell's aria-label is toggled (blanked, then restored on the next tick) so NVDA
+//    re-reads the date on every focus;
+//  - selecting a day refocuses it on a microtask (after flatpickr's own focus moves).
+// So assertions that read the restored aria-label / final focus must wait, not read synchronously.
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe("DatePicker Accessibility (W3C APG grid pattern)", () => {
 	const messageSingleDate = singleDate as unknown as IMessage;
 
-	it("Issue A - announces month/year changes via aria-live region", async () => {
-		const { getByTestId, findByRole } = render(
-			<Message message={messageSingleDate} />,
-		);
+	it("Issue A - announces via an assertive live region; month nav updates it", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
 
-		const openButton = getByTestId("button-open");
-		fireEvent.click(openButton);
-
-		await findByRole("dialog");
-
-		// Check aria-live region exists
-		const liveRegion = screen
-			.getByTestId("datepicker-message")
-			.querySelector('[aria-live="polite"]');
+		// The live region is assertive so the focused date interrupts/queues past NVDA's grid
+		// context and is spoken on every entry (a polite region was dropped on re-entry).
+		const liveRegion = root.querySelector("[aria-live]");
 		expect(liveRegion).toBeInTheDocument();
-		expect(liveRegion).toHaveAttribute("role", "status");
+		expect(liveRegion).toHaveAttribute("aria-live", "assertive");
+		expect(liveRegion).toHaveAttribute("role", "alert");
 		expect(liveRegion).toHaveAttribute("aria-atomic", "true");
+
+		// Changing the month via the nav button announces the new "Month Year" via the live region.
+		fireEvent.click(root.querySelector(".flatpickr-next-month") as Element);
+		await waitFor(() => expect(liveRegion?.textContent).toMatch(/^[A-Za-z]+ \d{4}$/));
 	});
 
-	it("Issue B - grid has aria-label and aria-description", async () => {
-		const { getByTestId, findByRole } = render(
-			<Message message={messageSingleDate} />,
-		);
+	it("Issue B - grid has role/label/description/counts and weekday columnheaders", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
 
-		const openButton = getByTestId("button-open");
-		fireEvent.click(openButton);
+		// role="grid" lives on the rContainer (wraps the weekday row + day grid).
+		const grid = root.querySelector(".flatpickr-rContainer");
+		expect(grid).toHaveAttribute("role", "grid");
+		expect(grid?.getAttribute("aria-label")).toBe("Calendar");
+		expect(grid?.getAttribute("aria-description")).toContain("arrow keys");
+		expect(grid).toHaveAttribute("aria-colcount", "7");
+		expect(grid).toHaveAttribute("aria-rowcount", "7"); // 1 weekday header row + 6 week rows
 
-		await findByRole("dialog");
-
-		const daysGrid = screen
-			.getByTestId("datepicker-message")
-			.querySelector(".flatpickr-innerContainer");
-		expect(daysGrid).toHaveAttribute("aria-label");
-		expect(daysGrid?.getAttribute("aria-label")).toBe("Calendar");
-		expect(daysGrid).toHaveAttribute("aria-description");
-		expect(daysGrid?.getAttribute("aria-description")).toContain("arrow keys");
-	});
-
-	it("Issue B - weekday headers have role and abbr", async () => {
-		const { getByTestId, findByRole } = render(
-			<Message message={messageSingleDate} />,
-		);
-
-		const openButton = getByTestId("button-open");
-		fireEvent.click(openButton);
-
-		await findByRole("dialog");
-
-		const weekdays = screen
-			.getByTestId("datepicker-message")
-			.querySelectorAll(".flatpickr-weekday");
+		// Weekday headers are columnheaders (aria-colindex 1-7) within the header row.
+		const weekdayRow = root.querySelector(".flatpickr-weekdays");
+		expect(weekdayRow).toHaveAttribute("role", "row");
+		expect(weekdayRow).toHaveAttribute("aria-rowindex", "1");
+		const weekdays = root.querySelectorAll(".flatpickr-weekday");
 		expect(weekdays.length).toBeGreaterThan(0);
-
-		weekdays.forEach(weekday => {
+		weekdays.forEach((weekday, i) => {
 			expect(weekday).toHaveAttribute("role", "columnheader");
 			expect(weekday).toHaveAttribute("abbr");
+			expect(weekday).toHaveAttribute("aria-colindex", String(i + 1));
 		});
 	});
 
-	it("Issue C - days grid has role='grid' for interactive announcement", async () => {
-		const { getByTestId, findByRole } = render(
-			<Message message={messageSingleDate} />,
-		);
+	it("Issue C - day cells are flat gridcells with row/column indices (no physical rows)", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
 
-		const openButton = getByTestId("button-open");
-		fireEvent.click(openButton);
+		const dayContainer = root.querySelector(".dayContainer");
+		expect(dayContainer).toHaveAttribute("role", "rowgroup");
 
-		await findByRole("dialog");
+		// Day cells are flat direct children (NOT wrapped in physical role="row" elements), so
+		// flatpickr's native arrow navigation can index them; grid position is conveyed via
+		// aria-rowindex / aria-colindex instead.
+		expect(dayContainer?.querySelectorAll('[role="row"]').length).toBe(0);
 
-		const daysGrid = screen
-			.getByTestId("datepicker-message")
-			.querySelector(".flatpickr-innerContainer");
-		expect(daysGrid).toHaveAttribute("role", "grid");
+		const days = getDayCells(root);
+		expect(days.length).toBe(42);
+		days.forEach((day, i) => {
+			expect(day).toHaveAttribute("role", "gridcell"); // not presentation -> NVDA tracks it
+			// Day rows start at grid row 2 (row 1 is the weekday header).
+			expect(day).toHaveAttribute("aria-rowindex", String(Math.floor(i / 7) + 2));
+			expect(day).toHaveAttribute("aria-colindex", String((i % 7) + 1));
+		});
 	});
 
-	it("Issue E - a day cell is made focusable and keyboard-navigable", async () => {
-		const { getByTestId, findByRole } = render(
-			<Message message={messageSingleDate} />,
+	it("Issue C - roving tabindex: exactly one focusable day, rest -1, grid not focusable", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		const days = Array.from(root.querySelectorAll<HTMLElement>(".flatpickr-day"));
+		const focusable = days.filter(d => d.getAttribute("tabindex") === "0");
+		expect(focusable).toHaveLength(1);
+		days.filter(d => d !== focusable[0]).forEach(d =>
+			expect(d).toHaveAttribute("tabindex", "-1"),
 		);
 
-		const openButton = getByTestId("button-open");
-		fireEvent.click(openButton);
+		// The inner container is no longer in the tab order and carries no activedescendant
+		// (focus lives on a day cell via roving tabindex).
+		const innerContainer = root.querySelector(".flatpickr-innerContainer");
+		expect(innerContainer).not.toHaveAttribute("tabindex");
+		expect(innerContainer).not.toHaveAttribute("aria-activedescendant");
+	});
 
-		await findByRole("dialog");
+	it("Issue D - day cells have a spoken date label (not MM/DD/YYYY)", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
 
-		const calendarContainer = screen.getByTestId("datepicker-message");
+		// First in-month day announces a spoken date, e.g. "June 1, 2026".
+		const firstInMonth = root.querySelector<HTMLElement>(
+			".dayContainer .flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)",
+		);
+		expect(firstInMonth?.getAttribute("aria-label")).toMatch(/^[A-Za-z]+ \d{1,2}, \d{4}$/);
+	});
 
-		// Check that day elements have tabindex (all -1 for aria-activedescendant pattern)
-		const dayElements = calendarContainer.querySelectorAll(".flatpickr-day");
-		expect(dayElements.length).toBeGreaterThan(0);
+	it("Issue E - arrow keys move roving focus one day at a time (single step)", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
 
-		dayElements.forEach(day => {
-			// Each day should have tabindex="-1" in aria-activedescendant pattern
-			expect(day).toHaveAttribute("tabindex", "-1");
-		});
+		const start = activeDay(root)!;
+		start.focus();
+		const startTime = dateOf(start)!.getTime();
 
-		// Grid container should have aria-activedescendant pointing to active day
-		const daysGrid = calendarContainer.querySelector(".flatpickr-innerContainer");
-		expect(daysGrid).toHaveAttribute("aria-activedescendant");
+		// ArrowRight -> the very next day (exactly one step), with real DOM focus.
+		pressKey("ArrowRight");
+		const afterRight = document.activeElement as HTMLElement;
+		expect(afterRight).not.toBe(start);
+		expect(afterRight.classList.contains("flatpickr-day")).toBe(true);
+		expect(dateOf(afterRight)!.getTime() - startTime).toBe(86_400_000); // +1 day
+		expect(root.querySelectorAll('.flatpickr-day[tabindex="0"]')).toHaveLength(1);
+		expect(activeDay(root)).toBe(afterRight); // roving tabindex follows DOM focus
 
-		const activeDayId = daysGrid?.getAttribute("aria-activedescendant");
-		expect(activeDayId).toBeTruthy();
+		// ArrowLeft -> back to the start day.
+		pressKey("ArrowLeft");
+		expect(dateOf(document.activeElement)!.getTime()).toBe(startTime);
 
-		// The element referenced by aria-activedescendant should exist
-		const activeDay = calendarContainer.querySelector(`#${activeDayId}`);
-		expect(activeDay).toBeInTheDocument();
+		// ArrowDown -> +1 week, ArrowUp -> back.
+		pressKey("ArrowDown");
+		expect(dateOf(document.activeElement)!.getTime() - startTime).toBe(7 * 86_400_000);
+		pressKey("ArrowUp");
+		expect(dateOf(document.activeElement)!.getTime()).toBe(startTime);
+		expect(root.querySelectorAll('.flatpickr-day[tabindex="0"]')).toHaveLength(1);
+
+		// The focused cell still ends up announcing its date (aria-label restored after toggle).
+		await waitFor(() => expect(focusedLabel()).toMatch(/^[A-Za-z]+ \d{1,2}, \d{4}$/));
+	});
+
+	it("Issue E - Home/End move within the focused week", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		activeDay(root)!.focus();
+
+		pressKey("End"); // last day (col 6) of the week
+		const endCol = getDayCells(root).indexOf(document.activeElement as HTMLElement) % 7;
+		expect(endCol).toBe(6);
+
+		pressKey("Home"); // first day (col 0) of the week
+		const homeCol = getDayCells(root).indexOf(document.activeElement as HTMLElement) % 7;
+		expect(homeCol).toBe(0);
+
+		expect(root.querySelectorAll('.flatpickr-day[tabindex="0"]')).toHaveLength(1);
+	});
+
+	it("Issue E - PageDown changes month keeping the same day; grid stays navigable", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		activeDay(root)!.focus();
+		const before = dateOf(document.activeElement)!;
+
+		pressKey("PageDown");
+		const after = dateOf(document.activeElement)!;
+		expect((document.activeElement as HTMLElement).classList.contains("flatpickr-day")).toBe(true);
+		expect(after.getDate()).toBe(before.getDate()); // same day-of-month
+		// Month advanced by one (wrapping year at December).
+		expect((after.getFullYear() - before.getFullYear()) * 12 + (after.getMonth() - before.getMonth())).toBe(1);
+		expect(root.querySelectorAll('.flatpickr-day[tabindex="0"]')).toHaveLength(1);
+
+		// Still navigable after the month change.
+		pressKey("ArrowRight");
+		expect(document.activeElement).toBe(activeDay(root));
+	});
+
+	it("Issue E - Shift+PageUp/PageDown change the year, keeping the same day", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		activeDay(root)!.focus();
+		const before = dateOf(document.activeElement)!;
+
+		pressKey("PageDown", true); // Shift+PageDown -> next year
+		const next = dateOf(document.activeElement)!;
+		expect(next.getFullYear()).toBe(before.getFullYear() + 1);
+		expect(next.getDate()).toBe(before.getDate());
+
+		pressKey("PageUp", true); // Shift+PageUp -> back a year
+		const back = dateOf(document.activeElement)!;
+		expect(back.getFullYear()).toBe(before.getFullYear());
+		expect(back.getDate()).toBe(before.getDate());
+	});
+
+	it("Issue E - arrow off the grid edge moves to the sequential adjacent-month day", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		// Last visible cell is a next-month overflow day; ArrowRight should land on the NEXT
+		// calendar day (sequential), not flatpickr's "first available day of the new month".
+		const last = getDayCells(root).at(-1)!;
+		const lastTime = dateOf(last)!.getTime();
+		last.setAttribute("tabindex", "0");
+		last.focus();
+
+		pressKey("ArrowRight");
+		await waitFor(() =>
+			expect((document.activeElement as HTMLElement).classList.contains("flatpickr-day")).toBe(true),
+		);
+		expect(dateOf(document.activeElement)!.getTime() - lastTime).toBe(86_400_000); // +1 day
+
+		// First visible cell is a prev-month overflow day; ArrowLeft -> previous calendar day.
+		const first = getDayCells(root)[0];
+		const firstTime = dateOf(first)!.getTime();
+		first.setAttribute("tabindex", "0");
+		first.focus();
+
+		pressKey("ArrowLeft");
+		await waitFor(() =>
+			expect((document.activeElement as HTMLElement).classList.contains("flatpickr-day")).toBe(true),
+		);
+		expect(firstTime - dateOf(document.activeElement)!.getTime()).toBe(86_400_000); // -1 day
+	});
+
+	it("Issue E - Enter selects the focused day and keeps roving focus valid", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		activeDay(root)!.focus();
+		pressKey("ArrowRight");
+		// fireEvent so React's onChange state update (enabling submit) flushes inside act();
+		// keyCode set so the event reaches the handler as a browser delivers it.
+		fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Enter", keyCode: 13 });
+
+		// Selection happened (submit button is now enabled).
+		expect(getByTestId("button-submit")).toBeEnabled();
+
+		// Selected gridcell is marked, and exactly one day remains focusable.
+		const selected = root.querySelector<HTMLElement>(".flatpickr-day.selected");
+		expect(selected).toHaveAttribute("aria-selected", "true");
+		await waitFor(() => expect(selected).toHaveAttribute("tabindex", "0"));
+		expect(root.querySelectorAll('.flatpickr-day[tabindex="0"]')).toHaveLength(1);
+	});
+
+	it("Issue F - opening the dialog moves focus to its (focusable) heading", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		await openDialog(findByRole, getByTestId);
+
+		const dialog = await findByRole("dialog");
+		const headingId = dialog.getAttribute("aria-labelledby");
+		const heading = headingId ? document.getElementById(headingId) : null;
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveAttribute("tabindex", "-1");
+		expect(document.activeElement).toBe(heading);
+	});
+
+	it("Issue G - Shift+Tab from a day is not hijacked to flatpickr's hidden input", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		activeDay(root)!.focus();
+		// flatpickr's own keydown would send Shift+Tab to its hidden input (a dead end); our
+		// handler stops that. jsdom does not perform native tab movement, so assert the negative:
+		// focus did NOT jump to the hidden input.
+		pressKey("Tab", true);
+		expect((document.activeElement as HTMLElement).classList.contains("flatpickr-input")).toBe(false);
+	});
+
+	it("Issue H - re-entering the grid re-announces the date (cell aria-label toggle)", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		const day = activeDay(root)!;
+		const dateLabel = day.getAttribute("aria-label");
+		const nextBtn = root.querySelector(".flatpickr-next-month") as HTMLElement;
+
+		// Capture the aria-label transitions so we can prove NVDA sees a fresh name on entry.
+		const transitions: (string | null)[] = [];
+		const observer = new MutationObserver(records =>
+			records.forEach(r => {
+				if (r.attributeName === "aria-label") {
+					transitions.push((r.target as HTMLElement).getAttribute("aria-label"));
+				}
+			}),
+		);
+		observer.observe(day, { attributes: true, attributeFilter: ["aria-label"] });
+
+		// Simulate focus arriving into the grid from outside (e.g. tabbing from the next-month
+		// button). The cell's name is toggled blank -> restored so NVDA re-reads it.
+		day.dispatchEvent(new FocusEvent("focusin", { bubbles: true, relatedTarget: nextBtn }));
+		await waitFor(() => expect(transitions).toEqual(["", dateLabel]));
+		observer.disconnect();
+
+		expect(day.getAttribute("aria-label")).toBe(dateLabel);
+	});
+
+	it("Issue H - focusing a day does NOT also write the date to the live region (no double announce)", async () => {
+		const { getByTestId, findByRole } = render(<Message message={messageSingleDate} />);
+		const root = await openDialog(findByRole, getByTestId);
+
+		const liveRegion = root.querySelector("[aria-live]") as HTMLElement;
+		const day = activeDay(root)!;
+		const dateLabel = day.getAttribute("aria-label") || "__none__";
+
+		const liveWrites: (string | null)[] = [];
+		const observer = new MutationObserver(() => liveWrites.push(liveRegion.textContent));
+		observer.observe(liveRegion, { childList: true, characterData: true, subtree: true });
+
+		day.dispatchEvent(
+			new FocusEvent("focusin", {
+				bubbles: true,
+				relatedTarget: root.querySelector(".flatpickr-next-month"),
+			}),
+		);
+		await flush();
+		observer.disconnect();
+
+		// The date is announced via the cell-name toggle only; the live region must not repeat it.
+		expect(liveWrites).not.toContain(dateLabel);
 	});
 });

--- a/test/DatepickerA11y.spec.tsx
+++ b/test/DatepickerA11y.spec.tsx
@@ -24,6 +24,16 @@ const getDayCells = (root: HTMLElement) =>
 // flatpickr stores the real Date for each day cell on `dateObj`.
 const dateOf = (cell: Element | null) => (cell as unknown as { dateObj?: Date } | null)?.dateObj;
 
+// Compare two dates by calendar date (year/month/day) only. Asserting raw getTime() deltas of
+// 86,400,000ms is DST-flaky: a midnight-to-midnight "day" is 23h or 25h across a DST transition.
+const ymd = (date: Date) => `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+// The calendar date N days after `from`, using local-date arithmetic (DST-safe, unlike ±86.4e6 ms).
+const addDays = (from: Date, days: number) => {
+	const date = new Date(from);
+	date.setDate(date.getDate() + days);
+	return date;
+};
+
 // Dispatch a keydown carrying a real keyCode. Flatpickr's native arrow navigation reads
 // e.keyCode, so arrow tests must set it (Testing Library's keyDown leaves keyCode at 0).
 const KEY_CODES: Record<string, number> = {
@@ -161,26 +171,26 @@ describe("DatePicker Accessibility (W3C APG grid pattern)", () => {
 
 		const start = activeDay(root)!;
 		start.focus();
-		const startTime = dateOf(start)!.getTime();
+		const startDate = dateOf(start)!;
 
 		// ArrowRight -> the very next day (exactly one step), with real DOM focus.
 		pressKey("ArrowRight");
 		const afterRight = document.activeElement as HTMLElement;
 		expect(afterRight).not.toBe(start);
 		expect(afterRight.classList.contains("flatpickr-day")).toBe(true);
-		expect(dateOf(afterRight)!.getTime() - startTime).toBe(86_400_000); // +1 day
+		expect(ymd(dateOf(afterRight)!)).toBe(ymd(addDays(startDate, 1))); // +1 calendar day
 		expect(root.querySelectorAll('.flatpickr-day[tabindex="0"]')).toHaveLength(1);
 		expect(activeDay(root)).toBe(afterRight); // roving tabindex follows DOM focus
 
 		// ArrowLeft -> back to the start day.
 		pressKey("ArrowLeft");
-		expect(dateOf(document.activeElement)!.getTime()).toBe(startTime);
+		expect(ymd(dateOf(document.activeElement)!)).toBe(ymd(startDate));
 
 		// ArrowDown -> +1 week, ArrowUp -> back.
 		pressKey("ArrowDown");
-		expect(dateOf(document.activeElement)!.getTime() - startTime).toBe(7 * 86_400_000);
+		expect(ymd(dateOf(document.activeElement)!)).toBe(ymd(addDays(startDate, 7)));
 		pressKey("ArrowUp");
-		expect(dateOf(document.activeElement)!.getTime()).toBe(startTime);
+		expect(ymd(dateOf(document.activeElement)!)).toBe(ymd(startDate));
 		expect(root.querySelectorAll('.flatpickr-day[tabindex="0"]')).toHaveLength(1);
 
 		// The focused cell still ends up announcing its date (aria-label restored after toggle).
@@ -254,7 +264,7 @@ describe("DatePicker Accessibility (W3C APG grid pattern)", () => {
 		// Last visible cell is a next-month overflow day; ArrowRight should land on the NEXT
 		// calendar day (sequential), not flatpickr's "first available day of the new month".
 		const last = getDayCells(root).at(-1)!;
-		const lastTime = dateOf(last)!.getTime();
+		const lastDate = dateOf(last)!;
 		last.setAttribute("tabindex", "0");
 		last.focus();
 
@@ -264,11 +274,11 @@ describe("DatePicker Accessibility (W3C APG grid pattern)", () => {
 				(document.activeElement as HTMLElement).classList.contains("flatpickr-day"),
 			).toBe(true),
 		);
-		expect(dateOf(document.activeElement)!.getTime() - lastTime).toBe(86_400_000); // +1 day
+		expect(ymd(dateOf(document.activeElement)!)).toBe(ymd(addDays(lastDate, 1))); // +1 calendar day
 
 		// First visible cell is a prev-month overflow day; ArrowLeft -> previous calendar day.
 		const first = getDayCells(root)[0];
-		const firstTime = dateOf(first)!.getTime();
+		const firstDate = dateOf(first)!;
 		first.setAttribute("tabindex", "0");
 		first.focus();
 
@@ -278,7 +288,7 @@ describe("DatePicker Accessibility (W3C APG grid pattern)", () => {
 				(document.activeElement as HTMLElement).classList.contains("flatpickr-day"),
 			).toBe(true),
 		);
-		expect(firstTime - dateOf(document.activeElement)!.getTime()).toBe(86_400_000); // -1 day
+		expect(ymd(dateOf(document.activeElement)!)).toBe(ymd(addDays(firstDate, -1))); // -1 calendar day
 	});
 
 	it("Issue E - Enter selects the focused day and keeps roving focus valid", async () => {

--- a/test/DatepickerA11y.spec.tsx
+++ b/test/DatepickerA11y.spec.tsx
@@ -22,8 +22,7 @@ const getDayCells = (root: HTMLElement) =>
 	Array.from(root.querySelectorAll<HTMLElement>(".dayContainer .flatpickr-day"));
 
 // flatpickr stores the real Date for each day cell on `dateObj`.
-const dateOf = (cell: Element | null) =>
-	(cell as unknown as { dateObj?: Date } | null)?.dateObj;
+const dateOf = (cell: Element | null) => (cell as unknown as { dateObj?: Date } | null)?.dateObj;
 
 // Dispatch a keydown carrying a real keyCode. Flatpickr's native arrow navigation reads
 // e.keyCode, so arrow tests must set it (Testing Library's keyDown leaves keyCode at 0).
@@ -214,10 +213,15 @@ describe("DatePicker Accessibility (W3C APG grid pattern)", () => {
 
 		pressKey("PageDown");
 		const after = dateOf(document.activeElement)!;
-		expect((document.activeElement as HTMLElement).classList.contains("flatpickr-day")).toBe(true);
+		expect((document.activeElement as HTMLElement).classList.contains("flatpickr-day")).toBe(
+			true,
+		);
 		expect(after.getDate()).toBe(before.getDate()); // same day-of-month
 		// Month advanced by one (wrapping year at December).
-		expect((after.getFullYear() - before.getFullYear()) * 12 + (after.getMonth() - before.getMonth())).toBe(1);
+		expect(
+			(after.getFullYear() - before.getFullYear()) * 12 +
+				(after.getMonth() - before.getMonth()),
+		).toBe(1);
 		expect(root.querySelectorAll('.flatpickr-day[tabindex="0"]')).toHaveLength(1);
 
 		// Still navigable after the month change.
@@ -256,7 +260,9 @@ describe("DatePicker Accessibility (W3C APG grid pattern)", () => {
 
 		pressKey("ArrowRight");
 		await waitFor(() =>
-			expect((document.activeElement as HTMLElement).classList.contains("flatpickr-day")).toBe(true),
+			expect(
+				(document.activeElement as HTMLElement).classList.contains("flatpickr-day"),
+			).toBe(true),
 		);
 		expect(dateOf(document.activeElement)!.getTime() - lastTime).toBe(86_400_000); // +1 day
 
@@ -268,7 +274,9 @@ describe("DatePicker Accessibility (W3C APG grid pattern)", () => {
 
 		pressKey("ArrowLeft");
 		await waitFor(() =>
-			expect((document.activeElement as HTMLElement).classList.contains("flatpickr-day")).toBe(true),
+			expect(
+				(document.activeElement as HTMLElement).classList.contains("flatpickr-day"),
+			).toBe(true),
 		);
 		expect(firstTime - dateOf(document.activeElement)!.getTime()).toBe(86_400_000); // -1 day
 	});
@@ -314,7 +322,9 @@ describe("DatePicker Accessibility (W3C APG grid pattern)", () => {
 		// handler stops that. jsdom does not perform native tab movement, so assert the negative:
 		// focus did NOT jump to the hidden input.
 		pressKey("Tab", true);
-		expect((document.activeElement as HTMLElement).classList.contains("flatpickr-input")).toBe(false);
+		expect((document.activeElement as HTMLElement).classList.contains("flatpickr-input")).toBe(
+			false,
+		);
 	});
 
 	it("Issue H - re-entering the grid re-announces the date (cell aria-label toggle)", async () => {

--- a/test/DatepickerA11y.spec.tsx
+++ b/test/DatepickerA11y.spec.tsx
@@ -1,0 +1,117 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { it, describe, expect } from "vitest";
+import Message from "src/messages/Message";
+import singleDate from "test/fixtures/datepicker/singleDate.json";
+import { IMessage } from "@cognigy/socket-client";
+
+describe("DatePicker Accessibility (Issues A, B, C, E)", () => {
+	const messageSingleDate = singleDate as unknown as IMessage;
+
+	it("Issue A - announces month/year changes via aria-live region", async () => {
+		const { getByTestId, findByRole } = render(
+			<Message message={messageSingleDate} />,
+		);
+
+		const openButton = getByTestId("button-open");
+		fireEvent.click(openButton);
+
+		await findByRole("dialog");
+
+		// Check aria-live region exists
+		const liveRegion = screen
+			.getByTestId("datepicker-message")
+			.querySelector('[aria-live="polite"]');
+		expect(liveRegion).toBeInTheDocument();
+		expect(liveRegion).toHaveAttribute("role", "status");
+		expect(liveRegion).toHaveAttribute("aria-atomic", "true");
+	});
+
+	it("Issue B - grid has aria-label and aria-description", async () => {
+		const { getByTestId, findByRole } = render(
+			<Message message={messageSingleDate} />,
+		);
+
+		const openButton = getByTestId("button-open");
+		fireEvent.click(openButton);
+
+		await findByRole("dialog");
+
+		const daysGrid = screen
+			.getByTestId("datepicker-message")
+			.querySelector(".flatpickr-innerContainer");
+		expect(daysGrid).toHaveAttribute("aria-label");
+		expect(daysGrid?.getAttribute("aria-label")).toBe("Calendar");
+		expect(daysGrid).toHaveAttribute("aria-description");
+		expect(daysGrid?.getAttribute("aria-description")).toContain("arrow keys");
+	});
+
+	it("Issue B - weekday headers have role and abbr", async () => {
+		const { getByTestId, findByRole } = render(
+			<Message message={messageSingleDate} />,
+		);
+
+		const openButton = getByTestId("button-open");
+		fireEvent.click(openButton);
+
+		await findByRole("dialog");
+
+		const weekdays = screen
+			.getByTestId("datepicker-message")
+			.querySelectorAll(".flatpickr-weekday");
+		expect(weekdays.length).toBeGreaterThan(0);
+
+		weekdays.forEach(weekday => {
+			expect(weekday).toHaveAttribute("role", "columnheader");
+			expect(weekday).toHaveAttribute("abbr");
+		});
+	});
+
+	it("Issue C - days grid has role='grid' for interactive announcement", async () => {
+		const { getByTestId, findByRole } = render(
+			<Message message={messageSingleDate} />,
+		);
+
+		const openButton = getByTestId("button-open");
+		fireEvent.click(openButton);
+
+		await findByRole("dialog");
+
+		const daysGrid = screen
+			.getByTestId("datepicker-message")
+			.querySelector(".flatpickr-innerContainer");
+		expect(daysGrid).toHaveAttribute("role", "grid");
+	});
+
+	it("Issue E - a day cell is made focusable and keyboard-navigable", async () => {
+		const { getByTestId, findByRole } = render(
+			<Message message={messageSingleDate} />,
+		);
+
+		const openButton = getByTestId("button-open");
+		fireEvent.click(openButton);
+
+		await findByRole("dialog");
+
+		const calendarContainer = screen.getByTestId("datepicker-message");
+
+		// Check that day elements have tabindex (all -1 for aria-activedescendant pattern)
+		const dayElements = calendarContainer.querySelectorAll(".flatpickr-day");
+		expect(dayElements.length).toBeGreaterThan(0);
+
+		dayElements.forEach(day => {
+			// Each day should have tabindex="-1" in aria-activedescendant pattern
+			expect(day).toHaveAttribute("tabindex", "-1");
+		});
+
+		// Grid container should have aria-activedescendant pointing to active day
+		const daysGrid = calendarContainer.querySelector(".flatpickr-innerContainer");
+		expect(daysGrid).toHaveAttribute("aria-activedescendant");
+
+		const activeDayId = daysGrid?.getAttribute("aria-activedescendant");
+		expect(activeDayId).toBeTruthy();
+
+		// The element referenced by aria-activedescendant should exist
+		const activeDay = calendarContainer.querySelector(`#${activeDayId}`);
+		expect(activeDay).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

Makes the Flatpickr-based **Datepicker** calendar fully usable with a keyboard and with screen readers (tested with NVDA). The calendar grid now follows the [W3C ARIA APG Date Picker Dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/) pattern.

Resolves [AB#118957](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/118957).

## Accessibility issues fixed

1. **Arrow keys "spelled out" numbers instead of moving the date (NVDA).**
   Day cells were `role="presentation"`, which hid them from the accessibility tree and forced NVDA into browse mode. Day cells are now real `role="gridcell"` elements and the grid uses a **roving tabindex** (exactly one focusable day), so arrow keys move the date selection and the screen reader tracks it.

2. **On open, no focused item was visible and the screen reader was silent.**
   Opening the dialog now moves focus to the dialog heading, so the screen reader announces the dialog, and the calendar has a single focusable day ready for the first Tab/arrow.

3. **Invalid/малformed grid semantics.**
   `role="grid"` is now on the correct container with `aria-label`, `aria-description`, `aria-colcount`/`aria-rowcount`; weekday headers are `role="columnheader"` with `aria-colindex`; day cells carry `aria-rowindex`/`aria-colindex`. (Flat cells — not physical row wrappers — so the library's native arrow navigation keeps working.)

4. **No spoken date / poor announcements.**
   Each day announces a natural spoken date (e.g. "June 23, 2026"), using the cell's own date so prev/next-month overflow cells announce their real month. The selected date is exposed via `aria-selected`.

5. **Incomplete keyboard support.**
   Added the full APG key set on top of the library's in-month arrows:
   - **Home / End** — first / last day of the focused week.
   - **PageUp / PageDown** — previous / next month, keeping the same day-of-month (falls back to the last day when the day doesn't exist).
   - **Shift + PageUp / PageDown** — previous / next year.
   - **Enter / Space** — select the focused day.
   - **Arrow across a month edge** — moves to the *sequential* next/previous calendar day (instead of jumping to the first day of the new month), which is far less confusing for screen-reader users.

6. **Reverse Tab could not leave the grid.**
   Shift+Tab was hijacked to a hidden input (a dead end). Focus now exits the grid normally to the surrounding controls.

7. **Selecting a date jerked focus to the time picker.**
   After picking a date, focus stayed on the time field (and caused a focus "flash" the screen reader announced) — disruptive when picking a range or multiple dates. Focus now **stays on the selected day** for single / range / multiple modes, with or without a time picker; the time fields remain reachable by Tab, and changing the time no longer pulls focus back into the grid.

8. **Date not re-announced when re-entering the grid.**
   On returning focus to the calendar, the focused day's date is now reliably re-announced on every entry (not just the first), with no duplicate announcement.

9. **No visible focus indicator** for the focused day (sighted keyboard users) — added.

## Tests

- Reworked `test/DatepickerA11y.spec.tsx` and `test/Datepicker.spec.tsx` to assert the final behavior (roving tabindex, grid roles/indices, all keyboard interactions, selection-keeps-focus, re-entry re-announcement). 148 tests pass; `tsc` and ESLint are clean.
- Note: jsdom can't run a real screen reader, so automated tests cover the DOM/focus contract. Actual NVDA verification is the manual "How to test" below.

---

## How to test

> ⚠️ Note: automated tests verify the markup/focus behavior, but **screen-reader speech must be checked manually** with a screen reader. 

### Option A — Quick check in the chat-components demo

1. In `chat-components`:
   ```bash
   npm ci
   npm run dev
   ```
2. Open the printed local URL (e.g. http://localhost:5173) in the browser.
3. Click the **Datepicker** tab at the top.
4. Click **Pick date** to open the calendar (test various calendar types like single, range, multiple dates etc.), then verify:
   - **Open:** focus lands on the dialog (NVDA announces "Calendar", dialog).
   - **Tab** into the calendar grid: a day cell is focused with a visible ring; NVDA announces the date (e.g. "June 23, 2026") — not individual digits.
   - **Arrow keys** move the focus by day; **↑/↓** by week. Each move announces the new date.
   - **Home / End** jump to the first / last day of the week.
   - **Page Up / Page Down** change the month (same day number); **Shift + Page Up / Page Down** change the year.
   - Arrowing **past the edge** of the month moves to the next/previous calendar day (e.g. after the last visible cell → the following day).
   - **Enter / Space** selects the focused day; focus **stays on that day** (you can keep navigating). Try the range / multiple datepickers too.
   - **Tab** moves to the time fields / Confirm; **Shift + Tab** moves back out of the grid (it does not get stuck).
   - **Esc** closes and returns focus to the Pick date button.
   - Re-enter the grid (Tab out and back): the focused date is announced again.

### Option B — Test inside Webchat (local build) against an endpoint

This mirrors how the component ships in the real Webchat widget.

1. **Build & pack chat-components** (in `chat-components`):
   ```bash
   npm ci && npm run build && npm pack
   ```
   This produces a tarball like `cognigy-chat-components-0.72.0.tgz` in the `chat-components` folder.

2. **Install it into Webchat** (in the `Webchat` folder, sibling to `chat-components`):
   ```bash
   npm i ../chat-components/cognigy-chat-components-0.72.0.tgz
   ```
   (Match the exact version/filename printed by `npm pack`.)

3. **Point Webchat at the test endpoint.** In `Webchat`, open `dist/index.html` and set the `initWebchat(...)` URL to:
   ```
   https://endpoint-dev.cognigy.ai/07d6ad7cf42f699d91db0a245dfa621381de0debfa412ffdc2e2e3a3c3bef443
   ```
   i.e.:
   ```html
   <script>
     initWebchat(
       "https://endpoint-dev.cognigy.ai/07d6ad7cf42f699d91db0a245dfa621381de0debfa412ffdc2e2e3a3c3bef443"
     );
   </script>
   ```

4. **Run Webchat** (in `Webchat`):
   ```bash
   npm run dev
   ```
   Open http://localhost:8787, open the chat, and trigger the **datepicker** message from the bot flow.

5. Run the **same checks as Option A** (open, arrow/Home/End/PageUp-Down/Shift+PageUp-Down navigation, Enter/Space to select, Tab/Shift+Tab in and out, Esc to close, re-entry re-announcement) with NVDA + Speech Viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
