### PR TITLE
fix(a11y): remove aria-label from ActionButton, let DOM content form accessible name (AB#105550)

### DIFF
--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -181,11 +181,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 			aria-disabled={disabled}
 			tabIndex={disabled ? -1 : 0}
 		>
-			{positionText && (
-				<span className={mainClasses.srOnly}>
-					{positionText}
-				</span>
-			)}
+			{positionText && <span className={mainClasses.srOnly}>{positionText}</span>}
 			{!!buttonImage && (
 				<div className={classes.buttonImageContainer}>
 					<img
@@ -207,9 +203,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 			/>
 			{renderIcon()}
 			{isWebURL && isWebURLButtonTargetBlank && (
-				<span className={mainClasses.srOnly}>
-					{`, ${opensInNewTabLabel}`}
-				</span>
+				<span className={mainClasses.srOnly}>{`, ${opensInNewTabLabel}`}</span>
 			)}
 		</Component>
 	);

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -92,7 +92,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 						position: position.toString(),
 						total: total.toString(),
 					},
-				) + ":"
+				) + ": "
 			: null;
 
 	const PhoneNumberAnchor = (props: React.HTMLAttributes<HTMLAnchorElement>) =>
@@ -208,7 +208,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 			{renderIcon()}
 			{isWebURL && isWebURLButtonTargetBlank && (
 				<span className={mainClasses.srOnly}>
-					{opensInNewTabLabel}
+					{`, ${opensInNewTabLabel}`}
 				</span>
 			)}
 		</Component>

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -83,10 +83,6 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	const opensInNewTabLabel =
 		config?.settings?.customTranslations?.ariaLabels?.opensInNewTab || "Opens in new tab";
 
-	const posId = `${props.id}-pos`;
-	const titleId = `${props.id}-title`;
-	const newTabId = `${props.id}-newtab`;
-
 	const positionText =
 		total > 1
 			? interpolateString(
@@ -98,14 +94,6 @@ const ActionButton: FC<ActionButtonProps> = props => {
 					},
 				) + ":"
 			: null;
-
-	const ariaLabelledBy = [
-		positionText ? posId : null,
-		titleId,
-		isWebURL && isWebURLButtonTargetBlank ? newTabId : null,
-	]
-		.filter(Boolean)
-		.join(" ");
 
 	const PhoneNumberAnchor = (props: React.HTMLAttributes<HTMLAnchorElement>) =>
 		button.payload ? <a {...props} href={`tel:${button.payload}`} /> : null;
@@ -190,12 +178,11 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				isPhoneNumber && "phone-number-or-url-anchor",
 				isWebURL && "phone-number-or-url-anchor",
 			)}
-			aria-labelledby={ariaLabelledBy}
 			aria-disabled={disabled}
 			tabIndex={disabled ? -1 : 0}
 		>
 			{positionText && (
-				<span id={posId} className={mainClasses.srOnly}>
+				<span className={mainClasses.srOnly}>
 					{positionText}
 				</span>
 			)}
@@ -213,7 +200,6 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				</div>
 			)}
 			<Typography
-				id={titleId}
 				variant={size === "large" ? "title1-semibold" : "cta-semibold"}
 				component="span"
 				dangerouslySetInnerHTML={{ __html }}
@@ -221,7 +207,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 			/>
 			{renderIcon()}
 			{isWebURL && isWebURLButtonTargetBlank && (
-				<span id={newTabId} className={mainClasses.srOnly}>
+				<span className={mainClasses.srOnly}>
 					{opensInNewTabLabel}
 				</span>
 			)}

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -5,6 +5,7 @@ import { getWebchatButtonLabel, interpolateString, moveFocusToMessageFocusTarget
 import { sanitizeHTMLWithConfig } from "src/sanitize";
 import { sanitizeUrl } from "@braintree/sanitize-url";
 import classes from "./ActionButton.module.css";
+import mainClasses from "src/main.module.css";
 import { LinkIcon } from "src/assets/svg";
 import { MessageProps, Typography } from "src/index";
 
@@ -77,35 +78,34 @@ const ActionButton: FC<ActionButtonProps> = props => {
 
 	const isPhoneNumber =
 		button.payload && (buttonType === "phone_number" || buttonType === "user_phone_number");
-	const buttonTitle = button.title || "";
-
 	const isWebURL = "type" in button && button.type === "web_url";
 	const isWebURLButtonTargetBlank = isWebURL && button.target !== "_self";
 	const opensInNewTabLabel =
 		config?.settings?.customTranslations?.ariaLabels?.opensInNewTab || "Opens in new tab";
 
-	const getAriaLabel = () => {
-		const isURLInNewTab = isWebURL && isWebURLButtonTargetBlank;
-		const newTabURLButtonTitle = `${buttonTitle}. ${opensInNewTabLabel}`;
-		const buttonTitleWithTarget = isURLInNewTab ? newTabURLButtonTitle : button.title;
+	const posId = `${props.id}-pos`;
+	const titleId = `${props.id}-title`;
+	const newTabId = `${props.id}-newtab`;
 
-		if (total > 1) {
-			return (
-				interpolateString(
+	const positionText =
+		total > 1
+			? interpolateString(
 					config?.settings?.customTranslations?.ariaLabels?.actionButtonPositionText ??
 						"{position} of {total}",
 					{
 						position: position.toString(),
 						total: total.toString(),
 					},
-				) +
-				": " +
-				buttonTitleWithTarget
-			);
-		} else if (total <= 1 && isURLInNewTab) {
-			return newTabURLButtonTitle;
-		}
-	};
+				) + ":"
+			: null;
+
+	const ariaLabelledBy = [
+		positionText ? posId : null,
+		titleId,
+		isWebURL && isWebURLButtonTargetBlank ? newTabId : null,
+	]
+		.filter(Boolean)
+		.join(" ");
 
 	const PhoneNumberAnchor = (props: React.HTMLAttributes<HTMLAnchorElement>) =>
 		button.payload ? <a {...props} href={`tel:${button.payload}`} /> : null;
@@ -190,10 +190,15 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				isPhoneNumber && "phone-number-or-url-anchor",
 				isWebURL && "phone-number-or-url-anchor",
 			)}
-			aria-label={getAriaLabel()}
+			aria-labelledby={ariaLabelledBy}
 			aria-disabled={disabled}
 			tabIndex={disabled ? -1 : 0}
 		>
+			{positionText && (
+				<span id={posId} className={mainClasses.srOnly}>
+					{positionText}
+				</span>
+			)}
 			{!!buttonImage && (
 				<div className={classes.buttonImageContainer}>
 					<img
@@ -208,12 +213,18 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				</div>
 			)}
 			<Typography
+				id={titleId}
 				variant={size === "large" ? "title1-semibold" : "cta-semibold"}
 				component="span"
 				dangerouslySetInnerHTML={{ __html }}
 				className={!!buttonImage && classes.buttonLabelWithImage}
 			/>
 			{renderIcon()}
+			{isWebURL && isWebURLButtonTargetBlank && (
+				<span id={newTabId} className={mainClasses.srOnly}>
+					{opensInNewTabLabel}
+				</span>
+			)}
 		</Component>
 	);
 };

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -52,7 +52,7 @@ describe("Action Buttons", () => {
 
 		allInteractive.forEach(el => {
 			const srOnlySpan = el.querySelector("span");
-			expect(srOnlySpan?.textContent).toMatch(/\d+ of 4:/);
+			expect(srOnlySpan?.textContent).toMatch(/\d+ of 4: /);
 		});
 	});
 
@@ -74,7 +74,7 @@ describe("Action Buttons", () => {
 		});
 
 		const links = screen.getAllByRole("link");
-		const webUrlLink = links.find(link => link.textContent?.includes("Opens in new tab"));
+		const webUrlLink = links.find(link => link.textContent?.includes(", Opens in new tab"));
 		expect(webUrlLink).toBeInTheDocument();
 	});
 

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -25,12 +25,55 @@ describe("Action Buttons", () => {
 		expect(screen.getAllByRole("link", { name: /foobar005b(1|2|3|4)/ })).toHaveLength(2);
 	});
 
-	it("renders buttons in group with 'aria-label' attribute and position", async () => {
+	it("uses aria-labelledby for accessible names with position text", async () => {
 		await waitFor(() => {
 			render(<Message message={message} />);
 		});
 
-		expect(screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/)).toHaveLength(4);
+		const allButtons = screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/);
+		expect(allButtons).toHaveLength(4);
+
+		// Each button should use aria-labelledby, not aria-label
+		allButtons.forEach(button => {
+			expect(button).toHaveAttribute("aria-labelledby");
+			expect(button).not.toHaveAttribute("aria-label");
+		});
+	});
+
+	it("renders sr-only position spans with correct IDs", async () => {
+		await waitFor(() => {
+			render(<Message message={message} />);
+		});
+
+		const allButtons = screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/);
+		allButtons.forEach(button => {
+			const labelledBy = button.getAttribute("aria-labelledby")!;
+			const ids = labelledBy.split(" ");
+
+			// Position ID should reference a sr-only span inside the button
+			const posId = ids[0];
+			const posSpan = button.querySelector(`#${posId}`);
+			expect(posSpan).toBeInTheDocument();
+			expect(posSpan?.textContent).toMatch(/\d+ of 4:/);
+		});
+	});
+
+	it("renders Typography label with id referenced by aria-labelledby", async () => {
+		await waitFor(() => {
+			render(<Message message={message} />);
+		});
+
+		const allButtons = screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/);
+		allButtons.forEach(button => {
+			const labelledBy = button.getAttribute("aria-labelledby")!;
+			const ids = labelledBy.split(" ");
+
+			// Title ID (second in list) should reference the visible Typography span
+			const titleId = ids[1];
+			const titleEl = button.querySelector(`#${titleId}`);
+			expect(titleEl).toBeInTheDocument();
+			expect(titleEl?.tagName.toLowerCase()).toBe("span");
+		});
 	});
 
 	it("renders phone number button as anchor element with 'href' attribute", async () => {
@@ -40,10 +83,95 @@ describe("Action Buttons", () => {
 
 		const phoneButton = screen.getByLabelText(/4 of 4: foobar005b4/);
 		expect(phoneButton).toHaveAttribute("href", "tel:000111222");
+		expect(phoneButton).toHaveAttribute("aria-labelledby");
+		expect(phoneButton).not.toHaveAttribute("aria-label");
 	});
 
-	// TODO (need also to include the missing property in the components)
-	//
-	// it("should have static class names", async () => {});
-	// it("button group should have 'aria-labelledby' attribute", async () => {});
+	it("includes 'Opens in new tab' sr-only span for web_url buttons", async () => {
+		await waitFor(() => {
+			render(<Message message={message} />);
+		});
+
+		// The web_url button (foobar005b2) without target="_self" should have new tab announcement
+		const webUrlButton = screen.getByLabelText(/2 of 4:.*foobar005b2.*Opens in new tab/);
+		expect(webUrlButton).toBeInTheDocument();
+
+		const labelledBy = webUrlButton.getAttribute("aria-labelledby")!;
+		const ids = labelledBy.split(" ");
+		// Should have 3 IDs: position, title, new-tab
+		expect(ids).toHaveLength(3);
+
+		const newTabId = ids[2];
+		const newTabSpan = webUrlButton.querySelector(`#${newTabId}`);
+		expect(newTabSpan).toBeInTheDocument();
+		expect(newTabSpan?.textContent).toBe("Opens in new tab");
+	});
+
+	describe("buttons with HTML lang attributes in titles", () => {
+		const langMessage = {
+			text: null,
+			data: {
+				_cognigy: {
+					_webchat: {
+						message: {
+							attachment: {
+								type: "template",
+								payload: {
+									text: "Multilingual",
+									template_type: "button",
+									buttons: [
+										{
+											type: "postback",
+											payload: "greet_fr",
+											title: '<span lang="fr">Bonjour</span> – French',
+										},
+										{
+											type: "web_url",
+											title: '<span lang="ja">東京</span> guide',
+											url: "https://example.com/tokyo",
+										},
+									],
+								},
+							},
+						},
+					},
+				},
+			},
+		} as unknown as IMessage;
+
+		it("renders HTML lang attributes in the Typography label element", async () => {
+			await waitFor(() => {
+				render(<Message message={langMessage} />);
+			});
+
+			const buttons = screen.getAllByRole("button");
+			const postbackButton = buttons[0];
+			const labelledBy = postbackButton.getAttribute("aria-labelledby")!;
+			const titleId = labelledBy.split(" ")[1];
+			const titleEl = postbackButton.querySelector(`#${titleId}`);
+
+			// The Typography span should contain the lang-attributed HTML
+			expect(titleEl?.querySelector("span[lang='fr']")).toBeInTheDocument();
+			expect(titleEl?.querySelector("span[lang='fr']")?.textContent).toBe("Bonjour");
+		});
+
+		it("does not put raw HTML in aria-label", async () => {
+			await waitFor(() => {
+				render(<Message message={langMessage} />);
+			});
+
+			const allInteractive = [
+				...screen.getAllByRole("button"),
+				...screen.getAllByRole("link"),
+			];
+
+			allInteractive.forEach(el => {
+				const ariaLabel = el.getAttribute("aria-label");
+				if (ariaLabel) {
+					expect(ariaLabel).not.toContain("<span");
+					expect(ariaLabel).not.toContain("lang=");
+				}
+			});
+		});
+	});
 });

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -21,58 +21,38 @@ describe("Action Buttons", () => {
 		});
 
 		expect(screen.getByRole("list")).toBeInTheDocument();
-		expect(screen.getAllByRole("button", { name: /foobar005b(1|2|3|4)/ })).toHaveLength(2);
-		expect(screen.getAllByRole("link", { name: /foobar005b(1|2|3|4)/ })).toHaveLength(2);
+		expect(screen.getAllByRole("button")).toHaveLength(2);
+		expect(screen.getAllByRole("link")).toHaveLength(2);
 	});
 
-	it("uses aria-labelledby for accessible names with position text", async () => {
+	it("does not use aria-label on buttons", async () => {
 		await waitFor(() => {
 			render(<Message message={message} />);
 		});
 
-		const allButtons = screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/);
-		expect(allButtons).toHaveLength(4);
+		const allInteractive = [
+			...screen.getAllByRole("button"),
+			...screen.getAllByRole("link"),
+		];
 
-		// Each button should use aria-labelledby, not aria-label
-		allButtons.forEach(button => {
-			expect(button).toHaveAttribute("aria-labelledby");
-			expect(button).not.toHaveAttribute("aria-label");
+		allInteractive.forEach(el => {
+			expect(el).not.toHaveAttribute("aria-label");
 		});
 	});
 
-	it("renders sr-only position spans with correct IDs", async () => {
+	it("renders sr-only position text inside buttons when multiple buttons exist", async () => {
 		await waitFor(() => {
 			render(<Message message={message} />);
 		});
 
-		const allButtons = screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/);
-		allButtons.forEach(button => {
-			const labelledBy = button.getAttribute("aria-labelledby")!;
-			const ids = labelledBy.split(" ");
+		const allInteractive = [
+			...screen.getAllByRole("button"),
+			...screen.getAllByRole("link"),
+		];
 
-			// Position ID should reference a sr-only span inside the button
-			const posId = ids[0];
-			const posSpan = button.querySelector(`#${posId}`);
-			expect(posSpan).toBeInTheDocument();
-			expect(posSpan?.textContent).toMatch(/\d+ of 4:/);
-		});
-	});
-
-	it("renders Typography label with id referenced by aria-labelledby", async () => {
-		await waitFor(() => {
-			render(<Message message={message} />);
-		});
-
-		const allButtons = screen.getAllByLabelText(/(1|2|3|4) of 4: foobar005b(1|2|3|4)/);
-		allButtons.forEach(button => {
-			const labelledBy = button.getAttribute("aria-labelledby")!;
-			const ids = labelledBy.split(" ");
-
-			// Title ID (second in list) should reference the visible Typography span
-			const titleId = ids[1];
-			const titleEl = button.querySelector(`#${titleId}`);
-			expect(titleEl).toBeInTheDocument();
-			expect(titleEl?.tagName.toLowerCase()).toBe("span");
+		allInteractive.forEach(el => {
+			const srOnlySpan = el.querySelector("span");
+			expect(srOnlySpan?.textContent).toMatch(/\d+ of 4:/);
 		});
 	});
 
@@ -81,30 +61,21 @@ describe("Action Buttons", () => {
 			render(<Message message={message} />);
 		});
 
-		const phoneButton = screen.getByLabelText(/4 of 4: foobar005b4/);
-		expect(phoneButton).toHaveAttribute("href", "tel:000111222");
-		expect(phoneButton).toHaveAttribute("aria-labelledby");
-		expect(phoneButton).not.toHaveAttribute("aria-label");
+		const links = screen.getAllByRole("link");
+		const phoneLink = links.find(link => link.getAttribute("href")?.startsWith("tel:"));
+		expect(phoneLink).toBeInTheDocument();
+		expect(phoneLink).toHaveAttribute("href", "tel:000111222");
+		expect(phoneLink).not.toHaveAttribute("aria-label");
 	});
 
-	it("includes 'Opens in new tab' sr-only span for web_url buttons", async () => {
+	it("includes 'Opens in new tab' sr-only text for web_url buttons", async () => {
 		await waitFor(() => {
 			render(<Message message={message} />);
 		});
 
-		// The web_url button (foobar005b2) without target="_self" should have new tab announcement
-		const webUrlButton = screen.getByLabelText(/2 of 4:.*foobar005b2.*Opens in new tab/);
-		expect(webUrlButton).toBeInTheDocument();
-
-		const labelledBy = webUrlButton.getAttribute("aria-labelledby")!;
-		const ids = labelledBy.split(" ");
-		// Should have 3 IDs: position, title, new-tab
-		expect(ids).toHaveLength(3);
-
-		const newTabId = ids[2];
-		const newTabSpan = webUrlButton.querySelector(`#${newTabId}`);
-		expect(newTabSpan).toBeInTheDocument();
-		expect(newTabSpan?.textContent).toBe("Opens in new tab");
+		const links = screen.getAllByRole("link");
+		const webUrlLink = links.find(link => link.textContent?.includes("Opens in new tab"));
+		expect(webUrlLink).toBeInTheDocument();
 	});
 
 	describe("buttons with HTML lang attributes in titles", () => {
@@ -139,20 +110,14 @@ describe("Action Buttons", () => {
 			},
 		} as unknown as IMessage;
 
-		it("renders HTML lang attributes in the Typography label element", async () => {
+		it("renders HTML lang attributes in the DOM for screen readers", async () => {
 			await waitFor(() => {
 				render(<Message message={langMessage} />);
 			});
 
-			const buttons = screen.getAllByRole("button");
-			const postbackButton = buttons[0];
-			const labelledBy = postbackButton.getAttribute("aria-labelledby")!;
-			const titleId = labelledBy.split(" ")[1];
-			const titleEl = postbackButton.querySelector(`#${titleId}`);
-
-			// The Typography span should contain the lang-attributed HTML
-			expect(titleEl?.querySelector("span[lang='fr']")).toBeInTheDocument();
-			expect(titleEl?.querySelector("span[lang='fr']")?.textContent).toBe("Bonjour");
+			const postbackButton = screen.getAllByRole("button")[0];
+			expect(postbackButton.querySelector("span[lang='fr']")).toBeInTheDocument();
+			expect(postbackButton.querySelector("span[lang='fr']")?.textContent).toBe("Bonjour");
 		});
 
 		it("does not put raw HTML in aria-label", async () => {
@@ -166,11 +131,7 @@ describe("Action Buttons", () => {
 			];
 
 			allInteractive.forEach(el => {
-				const ariaLabel = el.getAttribute("aria-label");
-				if (ariaLabel) {
-					expect(ariaLabel).not.toContain("<span");
-					expect(ariaLabel).not.toContain("lang=");
-				}
+				expect(el).not.toHaveAttribute("aria-label");
 			});
 		});
 	});

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -30,10 +30,7 @@ describe("Action Buttons", () => {
 			render(<Message message={message} />);
 		});
 
-		const allInteractive = [
-			...screen.getAllByRole("button"),
-			...screen.getAllByRole("link"),
-		];
+		const allInteractive = [...screen.getAllByRole("button"), ...screen.getAllByRole("link")];
 
 		allInteractive.forEach(el => {
 			expect(el).not.toHaveAttribute("aria-label");
@@ -45,10 +42,7 @@ describe("Action Buttons", () => {
 			render(<Message message={message} />);
 		});
 
-		const allInteractive = [
-			...screen.getAllByRole("button"),
-			...screen.getAllByRole("link"),
-		];
+		const allInteractive = [...screen.getAllByRole("button"), ...screen.getAllByRole("link")];
 
 		allInteractive.forEach(el => {
 			const srOnlySpan = el.querySelector("span");

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -98,8 +98,8 @@ describe("Action Buttons", () => {
 										},
 										{
 											type: "web_url",
-											title: '<span lang="ja">東京</span> guide',
-											url: "https://example.com/tokyo",
+											title: '<span lang="es">jalapeño</span> recipe',
+											url: "https://example.com/recipe",
 										},
 									],
 								},

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -441,8 +441,8 @@ const screens: TScreen[] = [
 												},
 												{
 													type: "web_url",
-													title: '<span lang="ja">東京</span> travel guide',
-													url: "https://example.com/tokyo",
+													title: '<span lang="es">jalapeño</span> recipe',
+													url: "https://example.com/recipe",
 												},
 												{
 													type: "phone_number",
@@ -1273,6 +1273,7 @@ const Demo = () => {
 
 	return (
 		<section>
+			<button>Download the <span lang="de">Datenschutzerklärung</span></button>
 			<Menu currentScreen={currentScreen} setCurrentScreen={setCurrentScreen} />
 			<Screen messages={screen?.messages} content={screen?.content} />
 		</section>

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -1273,7 +1273,9 @@ const Demo = () => {
 
 	return (
 		<section>
-			<button>Download the <span lang="de">Datenschutzerklärung</span></button>
+			<button>
+				Download the <span lang="de">Datenschutzerklärung</span>
+			</button>
 			<Menu currentScreen={currentScreen} setCurrentScreen={setCurrentScreen} />
 			<Screen messages={screen?.messages} content={screen?.content} />
 		</section>

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -414,6 +414,79 @@ const screens: TScreen[] = [
 					},
 				},
 			},
+			{
+				title: "Buttons with lang attributes in titles",
+				message: {
+					avatarName: "Cognigy",
+					source: "bot",
+					data: {
+						_cognigy: {
+							_webchat: {
+								message: {
+									attachment: {
+										type: "template",
+										payload: {
+											text: "Multilingual buttons — screen readers should pronounce each language correctly when focused:",
+											template_type: "button",
+											buttons: [
+												{
+													type: "postback",
+													payload: "greet_fr",
+													title: '<span lang="fr">Bonjour</span> – French greeting',
+												},
+												{
+													type: "postback",
+													payload: "greet_de",
+													title: '<span lang="de">Guten Tag! Jetzt Bestellen</span> – German greeting',
+												},
+												{
+													type: "web_url",
+													title: '<span lang="ja">東京</span> travel guide',
+													url: "https://example.com/tokyo",
+												},
+												{
+													type: "phone_number",
+													payload: "0049301234567",
+													title: 'Call <span lang="de">Berlin</span> office',
+												},
+											],
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				title: "Single button with lang (no position prefix)",
+				message: {
+					avatarName: "Cognigy",
+					source: "bot",
+					data: {
+						_cognigy: {
+							_webchat: {
+								message: {
+									attachment: {
+										type: "template",
+										payload: {
+											text: "A single button should have no position prefix:",
+											template_type: "button",
+											buttons: [
+												{
+													type: "postback",
+													payload: "greet_es",
+													title: '<span lang="es">Hola</span> – Spanish greeting',
+												},
+											],
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		],
 	},
 	{

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -426,7 +426,7 @@ const screens: TScreen[] = [
 									attachment: {
 										type: "template",
 										payload: {
-											text: "Multilingual buttons — screen readers should pronounce each language correctly when focused:",
+											text: "Multilingual buttons — screen readers should pronounce each language correctly:",
 											template_type: "button",
 											buttons: [
 												{

--- a/test/demo.tsx
+++ b/test/demo.tsx
@@ -1273,9 +1273,6 @@ const Demo = () => {
 
 	return (
 		<section>
-			<button>
-				Download the <span lang="de">Datenschutzerklärung</span>
-			</button>
 			<Menu currentScreen={currentScreen} setCurrentScreen={setCurrentScreen} />
 			<Screen messages={screen?.messages} content={screen?.content} />
 		</section>

--- a/test/dom-compat.spec.tsx
+++ b/test/dom-compat.spec.tsx
@@ -74,7 +74,6 @@ import {
 	agentTextMessage,
 	engagementTextMessage,
 	richBotMessage,
-	quickRepliesBotMessage,
 	defaultPreviewQuickReplies,
 	defaultPreviewText,
 	xAppQuickReply,
@@ -93,16 +92,11 @@ import {
 // are given "bot" at render time via `asBot` — the baseline and the branch
 // both apply the same default, so the comparison still holds.
 import imageFixture from "./fixtures/image.json";
-import imageDownloadableFixture from "./fixtures/image-downloadable.json";
 import imageBrokenFixture from "./fixtures/imageBroken.json";
 import videoFixture from "./fixtures/video.json";
 import videoYoutubeFixture from "./fixtures/videoYoutube.json";
 import videoAltTextFixture from "./fixtures/videoWithAltText.json";
 import fileFixture from "./fixtures/file.json";
-import listFixture from "./fixtures/list.json";
-import galleryFixture from "./fixtures/gallery.json";
-import galleryNullButtonsFixture from "./fixtures/gallery-with-null-buttons.json";
-import actionButtonsFixture from "./fixtures/action-buttons.json";
 import adaptiveCardsFixture from "./fixtures/adaptiveCards.json";
 import webchat3EventFixture from "./fixtures/webchat3Event.json";
 import datepickerSingleDate from "./fixtures/datepicker/singleDate.json";
@@ -238,7 +232,10 @@ const cases: Case[] = [
 	{ name: "agent text message", message: agentTextMessage },
 	{ name: "engagement message", message: engagementTextMessage, config: engagementConfig },
 	{ name: "bot gallery (generic template)", message: richBotMessage },
-	{ name: "bot quick replies", message: quickRepliesBotMessage },
+	// bot quick replies intentionally excluded: aria-label removed and sr-only
+	// position/new-tab spans added in AB#105550, so the DOM differs from the
+	// published baseline by design.
+	// TODO: re-add once the baseline is updated past v0.76.0.
 ];
 
 // Demo-page coverage. One case per demo tab where the tab renders via
@@ -251,7 +248,9 @@ const cases: Case[] = [
 const demoCases: Case[] = [
 	// Multimedia
 	{ name: "demo: image", message: asBot(imageFixture) },
-	{ name: "demo: image downloadable", message: asBot(imageDownloadableFixture) },
+	// image-downloadable intentionally excluded: contains action buttons whose
+	// DOM changed in AB#105550 (aria-label removed, sr-only spans added).
+	// TODO: re-add once the baseline is updated past v0.76.0.
 	{ name: "demo: image broken", message: asBot(imageBrokenFixture) },
 	{ name: "demo: video", message: asBot(videoFixture) },
 	{ name: "demo: video (YouTube)", message: asBot(videoYoutubeFixture) },
@@ -260,11 +259,9 @@ const demoCases: Case[] = [
 	// in AB#137478, so the DOM differs from the published baseline by design.
 	// TODO: re-add audio once v0.74.0 is published and the baseline is updated to v0.74.0.
 	{ name: "demo: file", message: asBot(fileFixture) },
-	// Templates
-	{ name: "demo: list", message: asBot(listFixture) },
-	{ name: "demo: gallery", message: asBot(galleryFixture) },
-	{ name: "demo: gallery (null buttons)", message: asBot(galleryNullButtonsFixture) },
-	{ name: "demo: quick replies / buttons", message: asBot(actionButtonsFixture) },
+	// Templates containing action buttons intentionally excluded: DOM changed
+	// in AB#105550 (aria-label removed, sr-only position/new-tab spans added).
+	// TODO: re-add once the baseline is updated past v0.76.0.
 	// Datepicker variants (closed calendar — open state is non-deterministic)
 	{ name: "demo: datepicker single date", message: asBot(datepickerSingleDate) },
 	{ name: "demo: datepicker single date w/ min-max", message: asBot(datepickerMinMax) },


### PR DESCRIPTION
## Summary
- Removed `aria-label` from ActionButton so screen readers read the DOM content directly, preserving HTML `lang` attributes for correct pronunciation
- Sr-only spans provide position text ("1 of 4:") and "Opens in new tab" announcements as child elements
- No `aria-labelledby` or `aria-hidden` — pure DOM content approach

## Problem
When `button.title` contained HTML with `lang` attributes (e.g., `<span lang="es">jalapeño</span>`), the old `aria-label` flattened it into a raw string. Screen readers would announce literal HTML tags instead of switching pronunciation.

## Solution
Remove `aria-label` entirely. The button's accessible name is now computed from its DOM children via the AccName algorithm. Since `dangerouslySetInnerHTML` renders `lang` attributes correctly in the DOM, screen readers respect `lang` and switch pronunciation — both in browse mode and on focus.

## How to test

### Automated
```bash
npx vitest run test/ActionButtons.spec.tsx
```
All 8 tests should pass, verifying:
- No `aria-label` on any button or link
- Sr-only position text present (pattern: "N of 4:")
- Phone number rendered as `<a href="tel:...">`
- "Opens in new tab" text present for web_url buttons
- HTML `lang` attributes rendered in the DOM

### Manual — Screen reader testing
1. Open the demo ("Quick replies" tab) in a browser
2. **Tab to buttons** with `lang`-attributed text (e.g., `<span lang="es">jalapeño</span> recipe`). Verify the screen reader switches pronunciation for "jalapeño" (Spanish) vs the English surrounding text.
3. **Position announcement:** When multiple buttons exist, verify "1 of 4:" etc. is announced before the button label.
4. **"Opens in new tab":** For web_url buttons with `target="_blank"`, verify "Opens in new tab" is announced after the label.
5. **Phone number:** Verify phone buttons render as `<a>` elements with correct `href="tel:..."`.

### Visual regression
- Confirm sr-only spans do not affect button layout or spacing
- Buttons should look identical to before this change