### PR TITLE
fix(action-button): neutralize javascript: URLs in web_url buttons (AB#90512)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ codeql-results-dist.sarif
 
 # Claude Code worktrees
 .worktrees/
+
+# Superpowers design specs (local only)
+docs/superpowers/

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -101,9 +101,19 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		   cannot see through the indirection. */
 		button.payload ? <a {...props} href={`tel:${button.payload}`} /> : null;
 	const Anchor = (props: React.HTMLAttributes<HTMLAnchorElement>) =>
-		/* eslint-disable-next-line jsx-a11y/anchor-has-content -- same render-prop pattern
-		   as PhoneNumberAnchor: children come in via the {...props} spread. */
-		isWebURL ? <a {...props} href={button.url} target={button.target} /> : null;
+		isWebURL ? (
+			/* eslint-disable-next-line jsx-a11y/anchor-has-content -- same render-prop pattern
+			   as PhoneNumberAnchor: children come in via the {...props} spread. */
+			<a
+				{...props}
+				href={
+					config?.settings?.layout?.disableUrlButtonSanitization
+						? button.url
+						: sanitizeUrl(button.url)
+				}
+				target={button.target}
+			/>
+		) : null;
 	const Button = (props: React.HTMLAttributes<HTMLButtonElement>) => (
 		<button {...props} disabled={disabled} />
 	);

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -135,22 +135,28 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		}
 
 		if (isWebURL) {
-			const url = config?.settings?.layout?.disableUrlButtonSanitization
-				? button.url
-				: sanitizeUrl(button.url);
+			if (config?.settings?.layout?.disableUrlButtonSanitization) {
+				// Escape hatch (opt-in, intentionally permissive): let native anchor
+				// navigation handle the raw href — including javascript: URLs.
+				// Deliberately no preventDefault / no window.open here.
+				return;
+			}
+
+			// Sanitized path owns navigation, so a neutralized URL can no-op.
+			event.preventDefault();
+
+			const url = sanitizeUrl(button.url);
 
 			// prevent no-ops from sending you to a blank page
 			if (url === "about:blank") return;
+
 			window.open(url, isWebURLButtonTargetBlank ? "_blank" : "_self");
+			return;
 		}
 
 		if (disabled) return;
 
 		event.preventDefault();
-
-		if (isWebURL) {
-			return;
-		}
 
 		if (buttonType === "openXApp") {
 			openXAppOverlay?.(button.payload);

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -79,6 +79,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	const isPhoneNumber =
 		button.payload && (buttonType === "phone_number" || buttonType === "user_phone_number");
 	const isWebURL = "type" in button && button.type === "web_url";
+	const sanitizedButtonUrl = sanitizeUrl(button.url);
 	const isWebURLButtonTargetBlank = isWebURL && button.target !== "_self";
 	const opensInNewTabLabel =
 		config?.settings?.customTranslations?.ariaLabels?.opensInNewTab || "Opens in new tab";
@@ -109,7 +110,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				href={
 					config?.settings?.layout?.disableUrlButtonSanitization
 						? button.url
-						: sanitizeUrl(button.url)
+						: sanitizedButtonUrl
 				}
 				target={button.target}
 			/>
@@ -145,7 +146,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 			// Sanitized path owns navigation, so a neutralized URL can no-op.
 			event.preventDefault();
 
-			const url = sanitizeUrl(button.url);
+			const url = sanitizedButtonUrl;
 
 			// prevent no-ops from sending you to a blank page
 			if (url === "about:blank") return;

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -79,8 +79,23 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	const isPhoneNumber =
 		button.payload && (buttonType === "phone_number" || buttonType === "user_phone_number");
 	const isWebURL = "type" in button && button.type === "web_url";
-	const sanitizedButtonUrl = sanitizeUrl(button.url);
+	// Only web_url buttons carry a navigable URL; skip sanitizing (and avoid
+	// passing an undefined url into sanitizeUrl) for postback/phone buttons.
+	const sanitizedButtonUrl = isWebURL ? sanitizeUrl(button.url) : undefined;
+	// The href rendered for web_url anchors: raw only when the consumer has
+	// explicitly opted out of sanitization, otherwise the sanitized value.
+	const webUrlHref = config?.settings?.layout?.disableUrlButtonSanitization
+		? button.url
+		: sanitizedButtonUrl;
 	const isWebURLButtonTargetBlank = isWebURL && button.target !== "_self";
+	// Whether activating the button actually opens a new tab — drives the
+	// sr-only announcement so it matches real behavior. The sanitized path
+	// navigates via window.open (new tab unless target is "_self"); the
+	// sanitization opt-out uses native anchor navigation, which only opens a
+	// new tab for an explicit target="_blank".
+	const opensInNewTab = config?.settings?.layout?.disableUrlButtonSanitization
+		? isWebURL && button.target === "_blank"
+		: isWebURLButtonTargetBlank;
 	const opensInNewTabLabel =
 		config?.settings?.customTranslations?.ariaLabels?.opensInNewTab || "Opens in new tab";
 
@@ -102,19 +117,9 @@ const ActionButton: FC<ActionButtonProps> = props => {
 		   cannot see through the indirection. */
 		button.payload ? <a {...props} href={`tel:${button.payload}`} /> : null;
 	const Anchor = (props: React.HTMLAttributes<HTMLAnchorElement>) =>
-		isWebURL ? (
-			/* eslint-disable-next-line jsx-a11y/anchor-has-content -- same render-prop pattern
-			   as PhoneNumberAnchor: children come in via the {...props} spread. */
-			<a
-				{...props}
-				href={
-					config?.settings?.layout?.disableUrlButtonSanitization
-						? button.url
-						: sanitizedButtonUrl
-				}
-				target={button.target}
-			/>
-		) : null;
+		/* eslint-disable-next-line jsx-a11y/anchor-has-content -- same render-prop pattern
+		   as PhoneNumberAnchor: children come in via the {...props} spread. */
+		isWebURL ? <a {...props} href={webUrlHref} target={button.target} /> : null;
 	const Button = (props: React.HTMLAttributes<HTMLButtonElement>) => (
 		<button {...props} disabled={disabled} />
 	);
@@ -139,12 +144,17 @@ const ActionButton: FC<ActionButtonProps> = props => {
 			if (config?.settings?.layout?.disableUrlButtonSanitization) {
 				// Escape hatch (opt-in, intentionally permissive): let native anchor
 				// navigation handle the raw href — including javascript: URLs.
-				// Deliberately no preventDefault / no window.open here.
+				// A disabled button must not act, so block its native navigation;
+				// otherwise defer to the anchor's native navigation (no window.open).
+				if (disabled) event.preventDefault();
 				return;
 			}
 
 			// Sanitized path owns navigation, so a neutralized URL can no-op.
 			event.preventDefault();
+
+			// A disabled button must not navigate.
+			if (disabled) return;
 
 			const url = sanitizedButtonUrl;
 
@@ -224,7 +234,7 @@ const ActionButton: FC<ActionButtonProps> = props => {
 				className={!!buttonImage && classes.buttonLabelWithImage}
 			/>
 			{renderIcon()}
-			{isWebURL && isWebURLButtonTargetBlank && (
+			{opensInNewTab && (
 				<span className={mainClasses.srOnly}>{`, ${opensInNewTabLabel}`}</span>
 			)}
 		</Component>

--- a/src/common/ActionButtons/ActionButton.tsx
+++ b/src/common/ActionButtons/ActionButton.tsx
@@ -82,11 +82,18 @@ const ActionButton: FC<ActionButtonProps> = props => {
 	// Only web_url buttons carry a navigable URL; skip sanitizing (and avoid
 	// passing an undefined url into sanitizeUrl) for postback/phone buttons.
 	const sanitizedButtonUrl = isWebURL ? sanitizeUrl(button.url) : undefined;
-	// The href rendered for web_url anchors: raw only when the consumer has
-	// explicitly opted out of sanitization, otherwise the sanitized value.
+	// Neutralize only dangerous URLs; keep safe URLs byte-identical. sanitizeUrl
+	// normalizes safe URLs (adds a trailing slash, lowercases scheme/host), so
+	// rendering its output for every href would silently change the rendered
+	// markup for consumers (e.g. `https://example.com` -> `https://example.com/`)
+	// — a breaking DOM change. `=== "about:blank"` is sanitizeUrl's dangerous-URL
+	// signal (it also catches obfuscated payloads like `java\tscript:`, since
+	// control chars are stripped before detection), so we only swap in that case.
 	const webUrlHref = config?.settings?.layout?.disableUrlButtonSanitization
 		? button.url
-		: sanitizedButtonUrl;
+		: sanitizedButtonUrl === "about:blank"
+			? "about:blank"
+			: button.url;
 	const isWebURLButtonTargetBlank = isWebURL && button.target !== "_self";
 	// Whether activating the button actually opens a new tab — drives the
 	// sr-only announcement so it matches real behavior. The sanitized path

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -1,5 +1,5 @@
-import { render, waitFor, screen } from "@testing-library/react";
-import { it, describe, expect } from "vitest";
+import { render, waitFor, screen, fireEvent, createEvent } from "@testing-library/react";
+import { it, describe, expect, vi, afterEach } from "vitest";
 import Message from "src/messages/Message";
 import buttons from "test/fixtures/action-buttons.json";
 import { IMessage } from "@cognigy/socket-client";
@@ -203,6 +203,82 @@ describe("web_url button URL sanitization", () => {
 
 			const link = screen.getByRole("link");
 			expect(link).toHaveAttribute("href", "https://example.com/");
+		});
+	});
+
+	describe("click behavior (Fix B)", () => {
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		const clickLinkAndGetEvent = (link: Element) => {
+			const clickEvent = createEvent.click(link);
+			fireEvent(link, clickEvent);
+			return clickEvent;
+		};
+
+		it("prevents native navigation and does not open a javascript: URL when sanitization is on", async () => {
+			const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+			await waitFor(() => {
+				render(
+					<Message
+						message={webUrlMessage("javascript:alert(1)")}
+						config={sanitizeOnConfig}
+					/>,
+				);
+			});
+
+			const clickEvent = clickLinkAndGetEvent(screen.getByRole("link"));
+			expect(clickEvent.defaultPrevented).toBe(true);
+			expect(openSpy).not.toHaveBeenCalled();
+		});
+
+		it("prevents native navigation and opens a safe URL via window.open when sanitization is on", async () => {
+			const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+			await waitFor(() => {
+				render(
+					<Message
+						message={webUrlMessage("https://example.com/")}
+						config={sanitizeOnConfig}
+					/>,
+				);
+			});
+
+			const clickEvent = clickLinkAndGetEvent(screen.getByRole("link"));
+			expect(clickEvent.defaultPrevented).toBe(true);
+			expect(openSpy).toHaveBeenCalledWith("https://example.com/", "_blank");
+		});
+
+		it("allows native navigation (no preventDefault, no window.open) for a javascript: URL when sanitization is disabled", async () => {
+			const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+			await waitFor(() => {
+				render(
+					<Message
+						message={webUrlMessage("javascript:alert(1)")}
+						config={sanitizeOffConfig}
+					/>,
+				);
+			});
+
+			const clickEvent = clickLinkAndGetEvent(screen.getByRole("link"));
+			expect(clickEvent.defaultPrevented).toBe(false);
+			expect(openSpy).not.toHaveBeenCalled();
+		});
+
+		it("allows native navigation for a safe URL when sanitization is disabled", async () => {
+			const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+			await waitFor(() => {
+				render(
+					<Message
+						message={webUrlMessage("https://example.com/")}
+						config={sanitizeOffConfig}
+					/>,
+				);
+			});
+
+			const clickEvent = clickLinkAndGetEvent(screen.getByRole("link"));
+			expect(clickEvent.defaultPrevented).toBe(false);
+			expect(openSpy).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -223,6 +223,7 @@ describe("web_url button URL sanitization", () => {
 				render(
 					<Message
 						message={webUrlMessage("javascript:alert(1)")}
+						action={() => {}}
 						config={sanitizeOnConfig}
 					/>,
 				);
@@ -239,6 +240,7 @@ describe("web_url button URL sanitization", () => {
 				render(
 					<Message
 						message={webUrlMessage("https://example.com/")}
+						action={() => {}}
 						config={sanitizeOnConfig}
 					/>,
 				);
@@ -255,6 +257,7 @@ describe("web_url button URL sanitization", () => {
 				render(
 					<Message
 						message={webUrlMessage("javascript:alert(1)")}
+						action={() => {}}
 						config={sanitizeOffConfig}
 					/>,
 				);
@@ -271,6 +274,7 @@ describe("web_url button URL sanitization", () => {
 				render(
 					<Message
 						message={webUrlMessage("https://example.com/")}
+						action={() => {}}
 						config={sanitizeOffConfig}
 					/>,
 				);
@@ -311,12 +315,108 @@ describe("web_url button URL sanitization", () => {
 			} as unknown as IMessage;
 
 			await waitFor(() => {
-				render(<Message message={message} config={sanitizeOnConfig} />);
+				render(<Message message={message} action={() => {}} config={sanitizeOnConfig} />);
 			});
 
 			const clickEvent = clickLinkAndGetEvent(screen.getByRole("link"));
 			expect(clickEvent.defaultPrevented).toBe(true);
 			expect(openSpy).toHaveBeenCalledWith("https://example.com/", "_self");
+		});
+
+		// A disabled web_url button (no `action` provided, so ActionButtons
+		// renders it disabled) must not navigate or execute in either mode.
+		describe("disabled buttons do not navigate", () => {
+			it("blocks window.open and prevents default when sanitization is on", async () => {
+				const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+				await waitFor(() => {
+					render(
+						<Message
+							message={webUrlMessage("https://example.com/")}
+							config={sanitizeOnConfig}
+						/>,
+					);
+				});
+
+				const clickEvent = clickLinkAndGetEvent(screen.getByRole("link"));
+				expect(clickEvent.defaultPrevented).toBe(true);
+				expect(openSpy).not.toHaveBeenCalled();
+			});
+
+			it("blocks native navigation of a javascript: URL when sanitization is disabled", async () => {
+				const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+				await waitFor(() => {
+					render(
+						<Message
+							message={webUrlMessage("javascript:alert(1)")}
+							config={sanitizeOffConfig}
+						/>,
+					);
+				});
+
+				const clickEvent = clickLinkAndGetEvent(screen.getByRole("link"));
+				expect(clickEvent.defaultPrevented).toBe(true);
+				expect(openSpy).not.toHaveBeenCalled();
+			});
+		});
+	});
+
+	// #83: the "opens in new tab" sr-only announcement must reflect real behavior.
+	describe("opens-in-new-tab announcement", () => {
+		const webUrlMessageWithTarget = (target?: string) =>
+			({
+				text: null,
+				data: {
+					_cognigy: {
+						_webchat: {
+							message: {
+								attachment: {
+									type: "template",
+									payload: {
+										text: "Links",
+										template_type: "button",
+										buttons: [
+											{
+												type: "web_url",
+												title: "Visit",
+												url: "https://example.com/",
+												...(target ? { target } : {}),
+											},
+										],
+									},
+								},
+							},
+						},
+					},
+				},
+			}) as unknown as IMessage;
+
+		it("announces new tab for an untargeted web_url when sanitization is on", async () => {
+			await waitFor(() => {
+				render(<Message message={webUrlMessageWithTarget()} config={sanitizeOnConfig} />);
+			});
+
+			expect(screen.getByRole("link").textContent).toContain("Opens in new tab");
+		});
+
+		it("does not announce new tab for an untargeted web_url when sanitization is disabled", async () => {
+			await waitFor(() => {
+				render(<Message message={webUrlMessageWithTarget()} config={sanitizeOffConfig} />);
+			});
+
+			expect(screen.getByRole("link").textContent).not.toContain("Opens in new tab");
+		});
+
+		it("announces new tab for target=_blank when sanitization is disabled", async () => {
+			await waitFor(() => {
+				render(
+					<Message
+						message={webUrlMessageWithTarget("_blank")}
+						config={sanitizeOffConfig}
+					/>,
+				);
+			});
+
+			expect(screen.getByRole("link").textContent).toContain("Opens in new tab");
 		});
 	});
 });

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -280,5 +280,43 @@ describe("web_url button URL sanitization", () => {
 			expect(clickEvent.defaultPrevented).toBe(false);
 			expect(openSpy).not.toHaveBeenCalled();
 		});
+
+		it("opens a safe URL in the same tab (_self) when the button target is _self", async () => {
+			const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+			const message = {
+				text: null,
+				data: {
+					_cognigy: {
+						_webchat: {
+							message: {
+								attachment: {
+									type: "template",
+									payload: {
+										text: "Links",
+										template_type: "button",
+										buttons: [
+											{
+												type: "web_url",
+												title: "Visit",
+												url: "https://example.com/",
+												target: "_self",
+											},
+										],
+									},
+								},
+							},
+						},
+					},
+				},
+			} as unknown as IMessage;
+
+			await waitFor(() => {
+				render(<Message message={message} config={sanitizeOnConfig} />);
+			});
+
+			const clickEvent = clickLinkAndGetEvent(screen.getByRole("link"));
+			expect(clickEvent.defaultPrevented).toBe(true);
+			expect(openSpy).toHaveBeenCalledWith("https://example.com/", "_self");
+		});
 	});
 });

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -204,6 +204,24 @@ describe("web_url button URL sanitization", () => {
 			const link = screen.getByRole("link");
 			expect(link).toHaveAttribute("href", "https://example.com/");
 		});
+
+		// Regression: sanitizeUrl normalizes safe URLs (adds a trailing slash),
+		// but the rendered href must stay byte-identical to the raw URL so this
+		// does not become a breaking DOM change for consumers. Only dangerous
+		// URLs are rewritten (to about:blank).
+		it("renders a non-normalized safe URL byte-identical when sanitization is on", async () => {
+			await waitFor(() => {
+				render(
+					<Message
+						message={webUrlMessage("https://example.com")}
+						config={sanitizeOnConfig}
+					/>,
+				);
+			});
+
+			const link = screen.getByRole("link");
+			expect(link).toHaveAttribute("href", "https://example.com");
+		});
 	});
 
 	describe("click behavior (Fix B)", () => {

--- a/test/ActionButtons.spec.tsx
+++ b/test/ActionButtons.spec.tsx
@@ -3,6 +3,7 @@ import { it, describe, expect } from "vitest";
 import Message from "src/messages/Message";
 import buttons from "test/fixtures/action-buttons.json";
 import { IMessage } from "@cognigy/socket-client";
+import { IWebchatConfig } from "src/messages/types";
 
 describe("Action Buttons", () => {
 	const message = buttons as unknown as IMessage;
@@ -127,6 +128,81 @@ describe("Action Buttons", () => {
 			allInteractive.forEach(el => {
 				expect(el).not.toHaveAttribute("aria-label");
 			});
+		});
+	});
+});
+
+describe("web_url button URL sanitization", () => {
+	// Single-button message so exactly one link is rendered.
+	const webUrlMessage = (url: string) =>
+		({
+			text: null,
+			data: {
+				_cognigy: {
+					_webchat: {
+						message: {
+							attachment: {
+								type: "template",
+								payload: {
+									text: "Links",
+									template_type: "button",
+									buttons: [{ type: "web_url", title: "Visit", url }],
+								},
+							},
+						},
+					},
+				},
+			},
+		}) as unknown as IMessage;
+
+	const sanitizeOnConfig = {
+		settings: { layout: { disableUrlButtonSanitization: false } },
+	} as IWebchatConfig;
+	const sanitizeOffConfig = {
+		settings: { layout: { disableUrlButtonSanitization: true } },
+	} as IWebchatConfig;
+
+	describe("rendered href (Fix A)", () => {
+		it("renders a javascript: URL as about:blank when sanitization is on (default)", async () => {
+			await waitFor(() => {
+				render(
+					<Message
+						message={webUrlMessage("javascript:alert(1)")}
+						config={sanitizeOnConfig}
+					/>,
+				);
+			});
+
+			const link = screen.getByRole("link");
+			expect(link).toHaveAttribute("href", "about:blank");
+		});
+
+		it("renders the raw javascript: URL when sanitization is disabled", async () => {
+			await waitFor(() => {
+				render(
+					<Message
+						message={webUrlMessage("javascript:alert(1)")}
+						config={sanitizeOffConfig}
+					/>,
+				);
+			});
+
+			const link = screen.getByRole("link");
+			expect(link).toHaveAttribute("href", "javascript:alert(1)");
+		});
+
+		it("leaves a safe https URL unchanged when sanitization is on", async () => {
+			await waitFor(() => {
+				render(
+					<Message
+						message={webUrlMessage("https://example.com/")}
+						config={sanitizeOnConfig}
+					/>,
+				);
+			});
+
+			const link = screen.getByRole("link");
+			expect(link).toHaveAttribute("href", "https://example.com/");
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes a security defect where `web_url` action buttons executed `javascript:` URLs even with URL sanitization on (the default). The anchor rendered a raw `href`, and the click handler's early return on `about:blank` skipped `event.preventDefault()`, so a sanitized `javascript:` URL still executed via the anchor's native navigation.

Two coordinated changes in `src/common/ActionButtons/ActionButton.tsx` (defense in depth):

- **Fix A — neutralize dangerous `href`s at render:** by default the anchor renders `about:blank` **only** when `sanitizeUrl` flags the URL as dangerous (e.g. `javascript:`/`data:`); safe URLs render **byte-identical** to the raw value (raw `button.url` is also used when `disableUrlButtonSanitization` is `true`). `target` unchanged. This is the load-bearing defense — it also closes non-click vectors (middle-click, Ctrl/Cmd-click, right-click "Open"/"Copy link", keyboard Enter).
- **Fix B — reorder the click handler:** the sanitized path now always calls `event.preventDefault()` before the `about:blank` no-op guard; the escape-hatch path (`disableUrlButtonSanitization: true`) returns early so native navigation proceeds.

## Tests

9 new tests in `test/ActionButtons.spec.tsx` (render `href` + click `defaultPrevented`/`window.open` across sanitize-on/off × javascript:/safe/`_self`, plus a byte-identical-safe-URL regression guard). Full suite green. a11y axe gate 44/44, `lint:a11y` clean.

> jsdom cannot execute `javascript:` navigations, so unit tests assert the **mechanism** (rendered `href` + `defaultPrevented` + `window.open` calls). Please re-run Webchat's real-browser cypress-axe / e2e suite on the version bump to confirm execute/no-execute end-to-end.

## Notes for consumers (Webchat)

- **Default (`disableUrlButtonSanitization: false`):** dangerous `web_url` URLs now render `href="about:blank"` and never navigate or execute. Safe URLs render **byte-identical** to before (only dangerous URLs are rewritten), so there is **no DOM-compat divergence** — verified `demo: list` (`https://example.com`) still matches the published baseline.
- **`disableUrlButtonSanitization: true` (opt-in) — behavior change:** buttons now navigate via **native anchor navigation** (honoring `target`) instead of `window.open`. Untargeted URLs open in the **same tab** rather than a new tab, and `javascript:` URLs **execute** (intentional — the opt-out means "do not sanitize"; consumers enabling this flag must ensure URLs are trusted).
- No ARIA/`role`/`alt`/`tabindex` changes → no "Accessibility changes" release-notes entry required.

## dom-compat status (pre-existing, NOT introduced by this PR)

`npm run test:dom-compat` shows **3 failures — `bot gallery`, `demo: audio`, `demo: gallery` — which also fail on `main`** (base commit = 3 failures; this PR = 3 failures). They are a missing `aria-controls` attribute on swiper / audio-menu buttons: the published `0.77.0` artifact (gitHead `a46e4e6`, = main's tip) emits `aria-controls` that a clean lockfile-faithful build does not reproduce, so it's a published-artifact/release-hygiene issue in `0.77.0` itself, not this PR. (The earlier `data-default-avatar` divergence is resolved — avatar PR #255 landed. Note `test:dom-compat` is an advisory, non-required check.)

AB#90512

🤖 Generated with [Claude Code](https://claude.com/claude-code)
