### PR TITLE
docs: fix DOM-compat gate command order in CLAUDE.md to match CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 - `npm run test:a11y` — axe gate only (`test/a11y.spec.tsx`).
 - `npm run lint:a11y` — a11y-only ESLint gate (`eslint.a11y.config.js`); what CI blocks on.
 - `npm run lint` — full ESLint (a11y rules included; rest is advisory SARIF in CI).
-- `npm run test:dom-compat:install-baseline && npm run build && npm run test:dom-compat` — DOM-compatibility gate vs. the latest published release.
+- `npm ci && npm run build && npm run test:dom-compat:install-baseline && npm run test:dom-compat` — DOM-compatibility gate vs. the latest published release. **Order matters** (mirrors `.github/workflows/dom-compat.yml`): build `dist/` against the clean lockfile-pinned tree *before* `install-baseline`, since that step aliases in the published release with `npm install --no-save` and can drift ranged deps in `node_modules`. Building after it produces false diffs (e.g. swiper/radix `aria-controls` mismatches on gallery/audio cases) that never happen on CI.
 
 ## Accessibility is non-negotiable
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 - `npm run test:a11y` — axe gate only (`test/a11y.spec.tsx`).
 - `npm run lint:a11y` — a11y-only ESLint gate (`eslint.a11y.config.js`); what CI blocks on.
 - `npm run lint` — full ESLint (a11y rules included; rest is advisory SARIF in CI).
-- `npm ci && npm run build && npm run test:dom-compat:install-baseline && npm run test:dom-compat` — DOM-compatibility gate vs. the latest published release. **Order matters** (mirrors `.github/workflows/dom-compat.yml`): build `dist/` against the clean lockfile-pinned tree *before* `install-baseline`, since that step aliases in the published release with `npm install --no-save` and can drift ranged deps in `node_modules`. Building after it produces false diffs (e.g. swiper/radix `aria-controls` mismatches on gallery/audio cases) that never happen on CI.
+- `npm ci && npm run build && npm run test:dom-compat:install-baseline && npm run test:dom-compat` — DOM-compatibility gate vs. the latest published release. **Order matters** (mirrors `.github/workflows/dom-compat.yml`): build `dist/` against the clean lockfile-pinned tree _before_ `install-baseline`, since that step aliases in the published release with `npm install --no-save` and can drift ranged deps in `node_modules`. Building after it produces false diffs (e.g. swiper/radix `aria-controls` mismatches on gallery/audio cases) that never happen on CI.
 
 ## Accessibility is non-negotiable
 


### PR DESCRIPTION
# Success criteria

- The CLAUDE.md "Commands" entry for the DOM-compat gate documents the same step order CI uses, so a local run reproduces CI instead of producing false failures.
- The order-sensitivity is explained in-line so the ordering isn't "helpfully" reverted later.

## What changed

The documented DOM-compat sequence in `CLAUDE.md` ran `install-baseline` **before** `build`:

```
npm run test:dom-compat:install-baseline && npm run build && npm run test:dom-compat
```

Reordered to mirror `.github/workflows/dom-compat.yml`:

```
npm ci && npm run build && npm run test:dom-compat:install-baseline && npm run test:dom-compat
```

A short "**Order matters**" note was added explaining the reason.

## Why

`test:dom-compat:install-baseline` runs `npm install --no-save chat-components-baseline@npm:@cognigy/chat-components@<v>`, which re-resolves the dependency tree and can drift ranged deps in `node_modules` (e.g. swiper `^12.1.2` → 12.2.0). Only the lockfile is left untouched. If `build` runs **after** that step, the branch's `dist/` bundle is built against the alias-shifted/drifted tree instead of the lockfile-pinned versions — producing false dom-compat failures (e.g. swiper/radix `aria-controls` diffs on gallery/audio cases) that never occur on CI. CI deliberately builds first (`npm ci` → `build` → `install-baseline` → `test:dom-compat`); local docs now match.

Docs-only change — no runtime/library code touched.

# How to test

1. `git checkout claude/quirky-bardeen-ace16b`
2. Run the corrected sequence from the updated CLAUDE.md line: `npm ci && npm run build && npm run test:dom-compat:install-baseline && npm run test:dom-compat`
3. Confirm it passes (42/42 dom-compat tests) — matching the order in `.github/workflows/dom-compat.yml`.

# Security

- [x] No security implications

# Accessibility (WCAG 2.2 AA)

Docs-only change; no message types, markup, or interactive behavior touched.

# Additional considerations

- Docs-only; no performance implications.

# Documentation Considerations

Internal contributor guide (CLAUDE.md) only — no end-user docs impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)