### PR TITLE
0.78.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.77.0",
+	"version": "0.78.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cognigy/chat-components",
-			"version": "0.77.0",
+			"version": "0.78.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
 				"@fontsource/figtree": "5.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cognigy/chat-components",
-	"version": "0.77.0",
+	"version": "0.78.0",
 	"type": "module",
 	"main": "./dist/chat-components.js",
 	"repository": {


### PR DESCRIPTION
Version bump only — releases the work merged to `main` since `v0.77.0` (2026-07-10).

## What this release ships

**Bug fixes**

- **`fix(action-button)`: neutralize `javascript:` URLs in `web_url` buttons** (#258, AB#90512) — dangerous URLs now render `href="about:blank"` and never navigate or execute, closing non-click vectors too (middle-click, Ctrl/Cmd-click, right-click "Open"/"Copy link", keyboard Enter). Safe URLs render **byte-identical** to before.
- **`bugfix(CSA-85062)`: gallery card title readability** (#249) — adds opt-in `layout.galleryCardTitleBelowImage`. Default is unchanged (title still overlays the image); when enabled, the title renders in the text block beneath the image where it stays readable on light images.

**Internal** (no consumer impact)

- `test(dom-compat)`: re-enable action-button cases now 0.77.0 is npm latest (#259, [AB#145851](https://cognigy.visualstudio.com/5368ee19-3e69-4195-822d-1d41989707f7/_workitems/edit/145851))
- `docs`: fix DOM-compat gate command order in CLAUDE.md to match CI (#260)

## Consumer notes

- **New public API:** `layout.galleryCardTitleBelowImage?: boolean` (absent/false = existing overlay layout).
- **Behavior change, opt-in path only —** `disableUrlButtonSanitization: true`: buttons now navigate via **native anchor navigation** (honoring `target`) instead of `window.open`. Untargeted URLs open in the **same tab** rather than a new tab, and `javascript:` URLs **execute** (intentional — opting out of sanitization means the consumer guarantees URLs are trusted).
- **No ARIA/`role`/`alt`/`tabindex` changes** → no "Accessibility changes" entry required.
- Default-path DOM is unchanged apart from title-less gallery cards no longer emitting an empty overlay `<h4>` (no visible effect).

## Verification

All gates green locally on this branch:

| Gate | Result |
| --- | --- |
| `npm test` | 238 passed |
| `npm run lint:a11y` | 0 errors |
| `npx prettier --check .` | clean |
| `npm run build && test:dom-compat:install-baseline && test:dom-compat` | 42/42 passed vs `0.77.0` baseline |

The 3 dom-compat failures noted as pre-existing in #258 (`bot gallery`, `demo: audio`, `demo: gallery`) no longer reproduce — the gate is fully green against the published `0.77.0` baseline.

Per #258, Webchat's real-browser cypress-axe / E2E suite will be re-run on the consuming version bump to confirm execute/no-execute end-to-end (jsdom cannot execute `javascript:` navigations).

## Downstream

Consumed by `@cognigy/webchat` 3.48.0, which bumps to `0.78.0` once this is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
