### PR TITLE
chore(tooling): exclude nested Claude Code worktrees from local quality gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,12 @@ codeql-results.sarif
 codeql-db
 codeql-results-dist.sarif
 
-# Claude Code worktrees
+# Claude Code worktrees — full checkouts of this repo nested inside it.
+# Also excluded from the local quality gates, which (unlike git) don't read
+# ignore files: eslint.config.js / eslint.a11y.config.js `ignores`,
+# vite.config.ts + vitest.dom-compat.config.ts `test.exclude`, .prettierignore.
 .worktrees/
+.claude/worktrees/
 
 # Superpowers design specs (local only)
 docs/superpowers/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,7 @@
 # PR template:
 .azuredevops/*
+
+# Nested Claude Code git worktrees — full checkouts of this repo under
+# .claude/worktrees/<name>. Formatting them would report every unformatted
+# file from unrelated branches; CI never sees them (fresh checkout).
+.claude/worktrees/

--- a/eslint.a11y.config.js
+++ b/eslint.a11y.config.js
@@ -39,6 +39,15 @@ export default [
 			"dist",
 			"dist-demo",
 			"node_modules",
+			// Nested Claude Code git worktrees: each is a full checkout of this
+			// repo (its own src/, test/ and node_modules) living under
+			// .claude/worktrees/<name>. Linting them reports every finding from
+			// unrelated branches as if it were a local violation, which CI never
+			// sees — it does a fresh checkout with no nested worktrees. Git
+			// already skips them via .git/info/exclude; ESLint doesn't read that.
+			// Scoped to worktrees/ so the tracked .claude/ content (agents,
+			// commands, skills) stays in scope exactly as it is on CI.
+			".claude/worktrees/**",
 			// Test-only mocks never ship; their DOM mimics third-party
 			// libraries and is exercised by the runtime axe gate instead.
 			"test/__mocks__",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,9 +20,11 @@ import { componentMapping } from "./eslint.a11y.config.js";
  */
 export default [
 	// Ignore patterns. dist-demo is the built demo bundle (npm run build:demo)
-	// — generated output, same as dist.
+	// — generated output, same as dist. .claude/worktrees/** holds nested
+	// Claude Code git worktrees (full checkouts of this repo); see the matching
+	// entry in eslint.a11y.config.js.
 	{
-		ignores: ["dist", "dist-demo"],
+		ignores: ["dist", "dist-demo", ".claude/worktrees/**"],
 	},
 
 	// Base JS recommended rules (apply to all files)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,13 +20,26 @@ export default defineConfig({
 		globals: true,
 		// Removed browser configuration due to unsupported headless preview provider error
 		setupFiles: ["./test/preSetup.js", "./test/setup.js"],
-		// The dom-compat spec is excluded from the default `npm test` run
-		// because it has preconditions (a production `dist/` build and the
-		// dynamically-installed `chat-components-baseline` alias) that only
-		// the dedicated dom-compat workflow / `npm run test:dom-compat`
-		// script arrange. vitest.dom-compat.config.ts narrows `include` to
-		// specifically that file for the dedicated run.
-		exclude: [...configDefaults.exclude, "test/dom-compat.spec.tsx"],
+		exclude: [
+			...configDefaults.exclude,
+			// The dom-compat spec is excluded from the default `npm test` run
+			// because it has preconditions (a production `dist/` build and the
+			// dynamically-installed `chat-components-baseline` alias) that only
+			// the dedicated dom-compat workflow / `npm run test:dom-compat`
+			// script arrange. vitest.dom-compat.config.ts narrows `include` to
+			// specifically that file for the dedicated run.
+			"test/dom-compat.spec.tsx",
+			// Nested Claude Code git worktrees (.claude/worktrees/<name>) are
+			// full checkouts of this repo, so their specs match Vitest's default
+			// `include` glob and get collected on top of the real suite — the
+			// root-anchored dom-compat pattern above doesn't cover their copy
+			// either. They also carry their own node_modules, so the duplicate
+			// React copy makes every collected rendering spec fail ("Cannot read
+			// properties of null (reading 'useContext')"). CI never hits this —
+			// fresh checkout, no nested worktrees — so exclude them to keep
+			// local runs matching CI.
+			"**/.claude/worktrees/**",
+		],
 		css: {
 			modules: {
 				classNameStrategy: "non-scoped",

--- a/vitest.dom-compat.config.ts
+++ b/vitest.dom-compat.config.ts
@@ -26,7 +26,10 @@ export default defineConfig({
 		globals: true,
 		setupFiles: ["./test/preSetup.js", "./test/setup.js"],
 		include: ["test/dom-compat.spec.tsx"],
-		exclude: configDefaults.exclude, // Vitest's default — no dom-compat exclusion
+		// Vitest's default — no dom-compat exclusion — plus the nested Claude
+		// Code worktrees guard from vite.config.ts. `include` above is already
+		// root-anchored, so this is belt-and-braces against a future widening.
+		exclude: [...configDefaults.exclude, "**/.claude/worktrees/**"],
 		css: {
 			modules: {
 				classNameStrategy: "non-scoped",


### PR DESCRIPTION
Nested git worktrees under `.claude/worktrees/<name>` are full checkouts of this repo, each with its own `src/`, `test/` and `node_modules`. The local quality gates have no way to know they aren't part of the tree under inspection, so with stray worktrees on disk they produce large numbers of failures that CI never sees (CI does a fresh checkout with no nested worktrees).

Observed with three stray worktrees present:

- **`npm run lint:a11y`** → 42 errors, 10 warnings, **every one of them from a file inside a nested worktree**. Zero from `src/` or `test/`.
- **`npm test`** → collected the nested specs on top of the real suite. Those worktrees' `node_modules` supply a second React copy, so every collected rendering spec died with `Cannot read properties of null (reading 'useContext')` (Audio, Avatar, Datepicker, DatepickerA11y, Gallery, List, Text, Video, `a11y.spec` × N worktrees). Zero real failures.

Git already skips these paths, but only via `.git/info/exclude` — local to one clone, and no linter reads it. This PR moves the exclusion into the repo's own config so it travels with the checkout.

## What changed

| File | Change |
| --- | --- |
| `eslint.a11y.config.js` | `".claude/worktrees/**"` added to `ignores` |
| `eslint.config.js` | same pattern added to `ignores` |
| `vite.config.ts` | `"**/.claude/worktrees/**"` added to `test.exclude`; array reflowed so each pattern carries its own comment |
| `vitest.dom-compat.config.ts` | `exclude` changed from `configDefaults.exclude` to `[...configDefaults.exclude, "**/.claude/worktrees/**"]` |
| `.prettierignore` | `.claude/worktrees/` added |
| `.gitignore` | `.claude/worktrees/` added under the existing "Claude Code worktrees" block |

Two deliberate choices worth a reviewer's attention:

- **Scoped to `worktrees/`, not all of `.claude/**`.** The tracked `.claude/` content (`agents/`, `commands/`, `skills/wcag-component/`) stays in scope exactly as it is on CI, so a future `.ts`/`.tsx` added under a skill is still linted locally and on CI alike. Ignoring all of `.claude/` would have created the same local↔CI divergence this PR is fixing, just in the other direction.
- **The `.gitignore` line is included** even though `.git/info/exclude` already covers it locally. Without it, a teammate who creates a nested worktree sees it as untracked in `git status`, and `prettier --check .` picks it up (Prettier 3 reads `.gitignore` by default). One-line addition in the block that already says "Claude Code worktrees".

The dom-compat side is worth calling out: the existing `test/dom-compat.spec.tsx` exclude is root-anchored, so it does **not** match a nested worktree's copy — `dom-compat.spec.tsx` was leaking into the default `npm test` run and failing on an unresolvable `../dist/chat-components.js` import. The new pattern closes that too.

# Success criteria

- `npm run lint:a11y` reports only findings from `src/`, `test/` and root config files, never from `.claude/worktrees/`, even with nested worktrees on disk
- `npm test` collects only the repo's own 17 test files, never a nested worktree's copies, and never `test/dom-compat.spec.tsx`
- `npm run test:dom-compat` still collects exactly `test/dom-compat.spec.tsx`
- `npx prettier --check .` ignores nested worktrees
- `git status` stays clean when a nested worktree exists, for any clone (not just ones with a hand-edited `.git/info/exclude`)
- Gate coverage on a CI-shaped tree (no nested worktrees) is **unchanged** — all of `src/` and `test/` still checked

# How to test

1. From a clean checkout of this branch, create two nested worktrees to reproduce the condition: `git worktree add --detach .claude/worktrees/verify-a HEAD` and `git worktree add --detach .claude/worktrees/verify-b HEAD~1`. That adds 89 lintable files and 16 spec files that don't belong to the tree under test.
2. `npm run lint:a11y` → exits 0. `npm run test:a11y` → exits 0, 44/44. `npx prettier --check .` → exits 0.
3. `npx vitest list --filesOnly` → exactly the 17 real files under `test/`, nothing under `.claude/`, no `dom-compat`.
4. `npx vitest list --filesOnly --config vitest.dom-compat.config.ts` → exactly `test/dom-compat.spec.tsx`.
5. To see the old behaviour for contrast, `git stash` the config changes and repeat step 3 — collection jumps to 31 files and `vitest list` errors out on the nested copies.
6. Clean up: `git worktree remove --force .claude/worktrees/verify-a && git worktree remove --force .claude/worktrees/verify-b && git worktree prune`.

**Coverage-parity check** (this is the one that matters for CI): with no nested worktrees present, dump the file list ESLint actually reports under the old config and the new one and diff them. I ran this and the lists are byte-identical — 97 files (66 `src/`, 24 `test/`, 7 root). Vitest collects the same 17 files either way.

# Security

- [x] No security implications

Config-only change to lint/test/format file-selection globs. No runtime, library or rendered-output code is touched, and the checks' rule sets are unchanged — only which paths they walk.

# Accessibility (WCAG 2.2 AA)

- [x] New message types have a case entry in `test/fixtures/message-cases.ts` — n/a, no new message types
- [x] Interaction spec (`<Component>A11y.spec.tsx`) added/updated — n/a, no component or interaction changes

No change to rendered DOM, so the DOM-compat contract is untouched and no release-notes "Accessibility changes" entry is needed. The a11y gates keep their exact coverage (verified above): the point of the change is that `lint:a11y` failures now mean something again instead of being buried under 42 findings from other branches.

# Additional considerations

- [ ] This PR might have performance implications

Local runs get faster as a side effect — `npm test` no longer transforms and collects a duplicate copy of the suite per stray worktree. CI timing is unaffected.

# Documentation Considerations

Nothing for the docs team — internal tooling only. The rationale lives in comments next to each ignore entry, and the `.gitignore` block cross-references the four gate configs so the set stays discoverable if one is ever edited in isolation.

## Reviewer note: a Node-version-dependent test failure (not caused by this PR)

`npm test` exits 1 **locally on Node 26**, on one failure unrelated to this change: `test/sanitize.spec.ts` › `sanitizeHTMLWithConfig > iframe srcdoc XSS Prevention (Zendesk Infosec Report) > preserves valid content while stripping dangerous parts in mixed srcdoc`.

It fails identically with the pristine `vite.config.ts`, and it fails on `main` / `release/0.78.0` in every worktree, so it is not attributable to this PR. **CI is green on this branch** (`build (22.x)` passes), which confirms it is environment-dependent, not repo debt: `package.json` declares `engines: >=22.1.0` but CI only tests `22.x`, so a developer on Node 24/26 hits a red `npm test` on a clean checkout of `main`. Worth its own ticket — either pin the supported range or fix the srcdoc expectation for newer jsdom/DOMPurify. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
