### PR TITLE
ci: create releases with GITHUB_TOKEN, publish on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+# Runs the test suite with node, then publishes the package to npm when a `v*`
+# tag is pushed. Authentication uses npm trusted publishing (OIDC) — there is no
+# static npm token involved.
+# For more information see: https://docs.npmjs.com/trusted-publishers
 
 name: Publish
 
@@ -17,7 +19,9 @@ on:
             - "v*"
     # Escape hatch: lets a maintainer re-run a failed publish against an existing
     # tag (`gh workflow run publish.yml --ref v0.79.0`) without deleting and
-    # re-pushing the tag. Always dispatch against a TAG ref, never a branch.
+    # re-pushing the tag. Must be dispatched against a TAG ref — the job-level
+    # `if` below enforces that, since dispatching from a branch would otherwise
+    # publish whatever happens to be on that branch.
     workflow_dispatch:
 
 permissions:
@@ -26,6 +30,9 @@ permissions:
 
 jobs:
     build:
+        # Tag refs only. Guards workflow_dispatch from a branch ref, which would
+        # otherwise publish whatever is on that branch under a version nobody tagged.
+        if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
@@ -43,6 +50,10 @@ jobs:
 
     publish-npm:
         needs: build
+        # Repeated deliberately: `needs` alone already skips this job when build is
+        # skipped, but this is the step that actually publishes — it should not rely
+        # on another job's guard to stay tag-only.
+        if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,22 @@
 
 name: Publish
 
+# Triggers on the tag push, NOT on `release: published`. release.yml creates the
+# GitHub release with the built-in GITHUB_TOKEN, and releases created by
+# GITHUB_TOKEN do not emit workflow-triggering events — so a `release` trigger
+# here would never fire.
+#
+# The FILENAME of this workflow (publish.yml) is part of the npm trusted-publisher
+# binding configured on npmjs.com. Renaming or moving this file breaks OIDC
+# authentication for `npm publish` until the npm-side config is updated to match.
 on:
-    release:
-        types: [published]
+    push:
+        tags:
+            - "v*"
+    # Escape hatch: lets a maintainer re-run a failed publish against an existing
+    # tag (`gh workflow run publish.yml --ref v0.79.0`) without deleting and
+    # re-pushing the tag. Always dispatch against a TAG ref, never a branch.
+    workflow_dispatch:
 
 permissions:
     id-token: write # Required for npm trusted publishing (OIDC)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,18 @@ on:
         tags:
             - "v*"
 
+# `contents: write` is what `repos.createRelease()` needs. Using the built-in
+# GITHUB_TOKEN instead of a hand-managed PAT removes the yearly-expiry failure
+# mode that broke v0.78.0: the RELEASE_ACTION_TOKEN PAT expired ~1 year after it
+# was set, and the release step failed with "Bad credentials".
+#
+# A release created by GITHUB_TOKEN does NOT emit a `release: published` event,
+# so publish.yml deliberately triggers on the tag push itself rather than on the
+# release. Do not "fix" publish.yml back to `release: published` without also
+# reverting this token change, or publishing will silently stop.
+permissions:
+    contents: write
+
 jobs:
     release:
         name: "Release"
@@ -15,4 +27,4 @@ jobs:
             - name: "Create release"
               uses: "ergebnis/.github/actions/github/release/create@1.8.0"
               with:
-                  github-token: "${{ secrets.RELEASE_ACTION_TOKEN }}"
+                  github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ Push the changes to the GitHub and create a PR.
 `git push --tags`
 
 This will trigger the GitHub Action to create a release on GitHub and will publish the package to npm.
+
+Both `release.yml` and `publish.yml` trigger on the tag push itself. Creating a
+GitHub release by hand does **not** publish to npm — if a publish run fails, re-run
+it against the existing tag instead:
+
+`gh workflow run publish.yml --ref v0.78.0`

--- a/README.md
+++ b/README.md
@@ -49,4 +49,7 @@ Both `release.yml` and `publish.yml` trigger on the tag push itself. Creating a
 GitHub release by hand does **not** publish to npm — if a publish run fails, re-run
 it against the existing tag instead:
 
-`gh workflow run publish.yml --ref v0.78.0`
+`gh workflow run publish.yml --ref <tag>`
+
+Dispatch against a tag ref (e.g. `v1.2.3`), never a branch. Publishing is guarded
+to `refs/tags/v*` and will skip on anything else.


### PR DESCRIPTION
# Success criteria

Pushing a `v*` tag creates a GitHub release and publishes to npm, with no hand-managed credential that can expire.

- Pushing a `v*` tag creates a GitHub release without a PAT — `release.yml` uses the built-in `GITHUB_TOKEN`
- Pushing a `v*` tag publishes to npm — `publish.yml` triggers on the tag push, not on `release: published`
- npm publishing keeps working over OIDC / trusted publishing (provenance attestation still produced)
- A failed publish can be re-run against an existing tag without deleting and re-pushing it
- `RELEASE_ACTION_TOKEN` becomes unreferenced and can be deleted and revoked

# Context

The `Release` workflow failed for `v0.78.0` ([run 30256013852](https://github.com/Cognigy/chat-components/actions/runs/30256013852)) with `##[error]Bad credentials`. `RELEASE_TAG: v0.78.0` was set correctly in the log, so the input was fine — `github.rest.repos.createRelease()` returned 401.

Root cause: the `RELEASE_ACTION_TOKEN` PAT expired. `gh secret list` shows it was last updated **2025-07-14**; the run failed **2026-07-27** — ~12.5 months, matching a classic PAT's 1-year expiry.

Impact: no release was created, so `publish.yml` (triggered on `release: published`) never fired and the package was never published. The 0.78.0 release was created manually with `gh release create v0.78.0 --generate-notes --verify-tag` to unblock publishing. 0.78.0 is now on npm as `latest` with a valid SLSA provenance attestation.

Rather than rotate the PAT — which just resets the clock on the same failure for ~2027-07 — this removes the credential.

# What changed

**`release.yml`** — `secrets.RELEASE_ACTION_TOKEN` → `secrets.GITHUB_TOKEN`, plus `permissions: contents: write` (the scope `createRelease()` needs).

**`publish.yml`** — trigger changed from `release: published` to `push: tags: v*`. This is required, not cosmetic: **a release created by `GITHUB_TOKEN` does not emit workflow-triggering events**, so a `release` trigger would silently never fire. Also adds `workflow_dispatch`.

**`README.md`** — documents that hand-creating a release no longer publishes, and how to re-run a publish.

## Reviewer notes

**Why `npm publish` was not folded into `release.yml`.** That was the obvious simplification and it is a trap. `publish.yml` authenticates to npm via trusted publishing / OIDC, and npm binds a trusted publisher to the repository **and the workflow filename** — npm's docs state all fields are exact and case-sensitive, and that npm does not validate the config when saved, so a mismatch only surfaces as an auth failure at publish time. Moving the publish step would have broken releases until an npm org admin repointed the trusted publisher. **Do not rename or move `publish.yml`** without updating the npm-side config; both workflows carry a comment saying so.

**The two triggers are now coupled.** `release.yml` using `GITHUB_TOKEN` is what forces `publish.yml` onto a tag trigger. Reverting either one alone silently stops publishing. Comments in both files record the dependency.

**`workflow_dispatch` is a deliberate addition.** The trigger change removes the manual-release recovery path actually used for 0.78.0. Dispatch replaces it (`gh workflow run publish.yml --ref v0.79.0`) — always against a tag ref, never a branch, since a branch dispatch would publish whatever is on that branch. Happy to drop it if you'd rather keep the surface minimal.

**Verified `contents: write` is grantable here.** Not assumed: `deploy-pages.yml` already requests `pages: write` + `id-token: write` via an explicit `permissions:` block and succeeds on every run, so per-workflow elevation is not capped on this repo.

**Not verifiable before merge.** The first real release is the only proof — this cannot be tested without pushing a `v*` tag. The step most likely to surprise us is `Check package version` in the build job: `technote-space/package-version-check-action@v1` documents support for semver tag pushes and `COMMIT_DISABLED: 1` keeps its auto-commit path off, but tag-push is a different code path in that action than `release`. Worth watching on 0.79.0.

# How to test

1. Review the trigger/permission coupling above — the correctness argument is mostly "these two changes must land together".
2. After merge, cut the next version as usual (`npm version minor` → PR → `git push --tags`).
3. Confirm `Release` succeeds and creates the release with generated notes.
4. Confirm `Publish` fires **on the tag push** (not on the release event) and both jobs pass — including `Check package version`.
5. Confirm the new version is on npm and still carries a provenance attestation:
   `npm view @cognigy/chat-components@<version> --json | jq '.dist.attestations'`
6. Once green, delete and revoke the `RELEASE_ACTION_TOKEN` secret — it is unreferenced after this PR.

# Security

- [x] Authentication/Access controls touched
- [x] Exchanges data with external systems

Net reduction in credential surface. Replaces a long-lived PAT with an ephemeral, per-run, automatically-scoped `GITHUB_TOKEN` limited to `contents: write`. No new secrets. npm auth is unchanged (still OIDC, no static token). After merge, `RELEASE_ACTION_TOKEN` can be revoked.

Separately noted for follow-up: the `NPM_TOKEN` secret (last updated 2025-12-15) is referenced by no workflow since the OIDC migration in 99515bf — an unused but presumably still-valid npm publish token that should be revoked and deleted. Out of scope here.

# Accessibility (WCAG 2.2 AA)

Not applicable — CI configuration only. No components, message types, or rendered output touched, so no `message-cases.ts` entry or interaction spec is required.

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

The release process in `README.md` is updated in this PR. The behavioral change worth communicating to maintainers: **creating a GitHub release by hand no longer publishes to npm.** Publishing is now bound to the tag push. Recovery for a failed publish is `gh workflow run publish.yml --ref <tag>`.
