### PR TITLE
test(sanitize): make mixed-srcdoc case tolerant of DOMPurify >= 3.3.2, widen CI Node matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,14 @@ jobs:
         runs-on: ubuntu-latest
 
         strategy:
+            # Report every Node version's result, so one failing line does not
+            # mask whether the others are green.
+            fail-fast: false
             matrix:
-                node-version: [22.x]
+                # Must cover every Node line permitted by `engines.node`
+                # (>=22.1.0), otherwise "supported" and "tested" drift apart and
+                # developers on newer Node hit failures CI never sees.
+                node-version: [22.x, 24.x, 26.x]
 
         steps:
             - uses: actions/checkout@v4

--- a/test/sanitize.spec.ts
+++ b/test/sanitize.spec.ts
@@ -379,11 +379,28 @@ describe("sanitizeHTMLWithConfig", () => {
 			const input =
 				'<iframe srcdoc="<h1>Title</h1><script>alert(1)</script><p>Safe paragraph</p>"></iframe>';
 			const result = sanitizeHTMLWithConfig(input, undefined);
-			expect(result).toContain("srcdoc");
-			expect(result).toContain("Title");
-			expect(result).toContain("Safe paragraph");
+
+			// The security contract holds under every DOMPurify version: no
+			// executable payload survives, however the srcdoc attribute is handled.
 			expect(result).not.toMatch(/<script/i);
 			expect(result).not.toContain("alert(1)");
+
+			// Whether the attribute survives at all is a DOMPurify implementation
+			// detail rather than part of our contract. Up to 3.3.1 the attribute is
+			// kept and `sanitizeSrcdocContent` scrubs the payload out of its value.
+			// From 3.3.2 on, DOMPurify drops any attribute whose value contains a
+			// raw-text end tag (`</script`, `</style`, `</iframe`, …) as mXSS
+			// hardening, so the whole `srcdoc` goes — safer, but the benign markup
+			// goes with it. Assert content preservation only in the branch where it
+			// is meaningful, matching the guard the payload-bearing tests above use.
+			if (result.includes("srcdoc")) {
+				expect(result).toContain("Title");
+				expect(result).toContain("Safe paragraph");
+			} else {
+				// Pin the strip-everything outcome so this branch cannot silently
+				// degrade into asserting nothing.
+				expect(result).toBe("<iframe></iframe>");
+			}
 		});
 
 		test("srcdoc sanitization result is stable (idempotent)", () => {


### PR DESCRIPTION
`npm test` went red on clean checkouts of `main` for developers on newer Node. The reported symptom was a Node-version split — green on Node 22, red on Node 26 — with one failing assertion in `test/sanitize.spec.ts`:

```
FAIL  sanitizeHTMLWithConfig > iframe srcdoc XSS Prevention (Zendesk Infosec Report)
      > preserves valid content while stripping dangerous parts in mixed srcdoc
AssertionError: expected '<iframe></iframe>' to contain 'srcdoc'
```

**Node is not the variable — `dompurify` is.** On a clean `npm ci` tree the whole suite passes on Node 26. Isolating the two dimensions:

| | dompurify 3.3.0 (lockfile pin) | dompurify 3.4.12 (what `^3.0.11` resolves to) |
|---|---|---|
| **Node 24.15.0** | 238 passed | ✗ same failure |
| **Node 26.5.0** | 238 passed | ✗ same failure |

Same Node + different dompurify changes the result; different Node + same dompurify does not.

### Root cause

DOMPurify **3.3.2** widened the `SAFE_FOR_XML` attribute-value check in `_sanitizeAttributes`:

```js
// 3.3.0 / 3.3.1
/((--!?|])>)|<\/(style|title|textarea)/i
// 3.3.2 and later
/((--!?|])>)|<\/(style|script|title|xmp|textarea|noscript|iframe|noembed|noframes)/i
```

Adding `script` means any attribute whose value contains `</script` is now **removed wholesale** — mXSS hardening against a value breaking out of a raw-text context on re-parse — before this repo's `sanitizeSrcdocContent` post-processing ever runs. So `srcdoc` is dropped rather than sanitized in place.

That also explains why only the mixed case failed: `</h1>`, `</p>`, `</ul>` and `</td>` are not raw-text end tags, so every sibling `srcdoc` case keeps its attribute on both versions.

**Why it looked Node-correlated:** trees where `dompurify` had drifted past the 3.3.0 lockfile pin. `npm run test:dom-compat:install-baseline` installs with `npm install --no-save`, which can bump ranged deps in `node_modules` — the drift `CLAUDE.md` already warns about for this gate. A plain `npm ci` restores 3.3.0.

### Why the test changed and not the sanitizer

Dropping the attribute entirely is the **safer** of the two outcomes and is upstream's deliberate security decision. Re-attaching a `srcdoc` that DOMPurify just removed would mean weakening a sanitizer to satisfy a test, so `src/sanitize.ts` is untouched.

The test now asserts the security contract unconditionally (`not.toMatch(/<script/i)`, `not.toContain("alert(1)")`) and guards the content-preservation assertions behind `if (result.includes("srcdoc"))` — the same pattern the four other payload-bearing tests in this describe block already use. The `else` branch pins `<iframe></iframe>` exactly, so the relaxed branch cannot silently decay into asserting nothing.

### Closing the supported-vs-tested gap

`engines.node` claims `>=22.1.0` but CI only ran `22.x`. The matrix is now `[22.x, 24.x, 26.x]` with `fail-fast: false` so one red line does not mask the others. `engines` is left as-is: the gap is closed by testing the declared range rather than by narrowing it.

Noticed while fixing an unrelated tooling issue in #262 and deliberately left out of scope there.

# Success criteria

- `npm test` passes on Node 22, 24 and 26
- `npm test` passes whether `node_modules/dompurify` is at the 3.3.0 lockfile pin or has drifted to 3.4.x, so running the dom-compat baseline install no longer leaves the default suite red
- The mixed-srcdoc test still fails if an executable payload ever survives sanitization, under either DOMPurify behavior
- CI reports a result for every Node line permitted by `engines.node`

# How to test

1. `npm ci && npm test` — 238 passed (this is the 3.3.0 lockfile pin).
2. `npm install --no-save dompurify@3.4.12 && npm test` — still 238 passed. On `main` this is the failing state.
3. `npm ci` to restore the pinned tree.
4. Optionally repeat step 1 on Node 24 and Node 26 — both build and test clean.

To see the underlying DOMPurify change directly, sanitize `<iframe srcdoc="<h1>Title</h1><script>alert(1)</script><p>Safe paragraph</p>"></iframe>` under 3.3.1 (keeps `srcdoc`) and 3.3.2 (drops it).

# Security

- [x] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [x] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [ ] No security implications

Test-only change to an XSS regression test; no sanitizer behavior is modified. The security assertions are now unconditional rather than gated behind an attribute-presence check, so the XSS contract this test guards is enforced at least as strictly as before. The `srcdoc` handling that actually differs between DOMPurify versions is strictly *more* aggressive in the newer one.

# Accessibility (WCAG 2.2 AA)

- [ ] New message types have a case entry in `test/fixtures/message-cases.ts` (one entry covers both the axe and DOM-compat gates)
- [ ] Interaction spec (`<Component>A11y.spec.tsx`) added/updated for new or changed interactive behavior

No new message types and no interactive behavior changed — no `src/` change at all. `npm run lint:a11y` and `test:a11y` both pass. The `srcdoc` attribute appears only in `src/sanitize.ts`'s allowlist and this spec; no renderer reads it and no corpus fixture contains one, so the DOM-compat contract is unaffected and no version-aware skip or release-note entry is needed.

# Additional considerations

- [ ] This PR might have performance implications

CI now runs three matrix legs instead of one, so the Test workflow uses roughly 3× the runner minutes. The legs run in parallel, so wall-clock is unchanged.

# Documentation Considerations

None for the docs team. One follow-up worth a maintainer decision, deliberately **not** taken here: `dist/` bundles `dompurify`, so shipped sanitizer behavior is fixed by the lockfile (3.3.0) and releases stay deterministic — but a future `npm update` would silently switch `srcdoc` handling to strip-the-attribute. The full suite is green on 3.4.12, so upgrading looks clean; the alternative is exact-pinning `dompurify` the way `adaptivecards` and `react-markdown` already are. Pinning a security dependency changes the published dependency graph for Webchat, so that call is left to maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
