### PR TITLE
AB#10000 fix(datepicker): restore year stepper arrows (CSA-92602)

### DIFF
--- a/src/messages/DatePicker/DatePicker.module.css
+++ b/src/messages/DatePicker/DatePicker.module.css
@@ -273,13 +273,78 @@
 } */
 
 .wrapper .content :global(.flatpickr-current-month .numInputWrapper) {
-	width: 60px;
+	/* Wide enough that the centred 4-digit year clears the 14px arrow column on the right. */
+	width: 76px;
 	height: 44px;
 }
 
+/*
+** Year stepper arrows. Flatpickr builds these itself (createNumberInput("cur-year")) and wires
+** up click-to-increment natively, but the flatpickr.css port above only copied the
+** .numInputWrapper wrapper/input rules and skipped every `.numInputWrapper span` rule, so the
+** arrows had no geometry and were explicitly hidden. Restore flatpickr's own geometry, with
+** three deliberate departures from stock: the glyph colour comes from a theme token instead of
+** flatpickr's hardcoded rgba(); the arrows stay visible at rest rather than revealing on
+** `.numInputWrapper:hover` (the whole complaint in CSA-92602 is that the year reads as a static
+** box, which a hover-gated affordance would not fix); and they carry no hover background, with
+** a wider hit area instead of flatpickr's cramped 14px one.
+*/
 .wrapper .content :global(.flatpickr-current-month .numInputWrapper span.arrowUp),
 .wrapper .content :global(.flatpickr-current-month .numInputWrapper span.arrowDown) {
-	display: none;
+	position: absolute;
+	right: 1px;
+	width: 24px;
+	height: 50%;
+	padding: 0 7px 0 7px;
+	box-sizing: border-box;
+	line-height: 50%;
+	cursor: pointer;
+	opacity: 1;
+}
+
+.wrapper .content :global(.flatpickr-current-month .numInputWrapper span.arrowUp) {
+	top: 1px;
+}
+
+.wrapper .content :global(.flatpickr-current-month .numInputWrapper span.arrowDown) {
+	top: 50%;
+}
+
+.wrapper .content :global(.flatpickr-current-month .numInputWrapper span:after) {
+	display: block;
+	content: "";
+	position: absolute;
+	border-left: 4px solid transparent;
+	border-right: 4px solid transparent;
+}
+
+.wrapper .content :global(.flatpickr-current-month .numInputWrapper span.arrowUp:after) {
+	border-bottom: 4px solid var(--cc-black-10);
+	top: 26%;
+}
+
+.wrapper .content :global(.flatpickr-current-month .numInputWrapper span.arrowDown:after) {
+	border-top: 4px solid var(--cc-black-10);
+	top: 40%;
+}
+
+/*
+** flatpickr disables the year input when minDate/maxDate pin it to a single year, but it does
+** not disable the arrows. Mute them off the input's state (they follow it in the DOM) so they
+** match the disabled treatment the nav and time arrows already get.
+*/
+.wrapper
+	.content
+	:global(.flatpickr-current-month .numInputWrapper input.cur-year[disabled] ~ span) {
+	cursor: default;
+	pointer-events: none;
+}
+
+.wrapper
+	.content
+	:global(.flatpickr-current-month .numInputWrapper input.cur-year[disabled] ~ span:after) {
+	border-bottom-color: var(--cc-black-80);
+	border-top-color: var(--cc-black-80);
 }
 
 .wrapper .content :global(.flatpickr-current-month input.cur-year) {
@@ -779,8 +844,9 @@
 		font-size: 16px;
 	}
 
+	/* Same reasoning as the base rule, scaled for the 16px anti-auto-zoom font size. */
 	.wrapper .content :global(.flatpickr-current-month .numInputWrapper) {
-		width: 64px;
+		width: 80px;
 	}
 
 	.wrapper .content :global(.flatpickr-current-month input.cur-year) {


### PR DESCRIPTION
# Success criteria

- The Date Picker calendar's Year field shows up/down stepper arrows at rest, with a pointer cursor on hover.
- Clicking the arrows changes the year and re-renders the day grid.
- The year value is not clipped or overlapped by the arrows, at both the default and <575px breakpoints.
- The arrows are muted and inert when `minDate`/`maxDate` pin the year to a single value.
- Time picker arrows, and every other message type, are visually unchanged.
- 
<img width="481" height="430" alt="image" src="https://github.com/user-attachments/assets/bf82cb2b-5582-4988-b8de-49418dd19d29" />

# How to test

1. `npm run dev`, open a Date Picker message, open the calendar.
2. Confirm the Year field shows ▲/▼ arrows without hovering; click them and watch the grid change year.
3. Load the `singleDateWithMinMax` fixture and confirm the arrows are muted/inert at the range bounds.
4. Check the `timeOnly` and `noTime` fixtures — time arrows unchanged.
5. Narrow the window below 575px and repeat step 2.
6. Keyboard regression: Tab to the year input, press ArrowUp/ArrowDown; and from the day grid, Shift+PageUp/PageDown.

## Root cause

Flatpickr already builds a complete year stepper — `createNumberInput("cur-year")` emits `input.cur-year` plus `span.arrowUp`/`span.arrowDown`, with click-to-increment wired natively. Two things in this repo hid it:

1. `DatePicker.module.css` ports `flatpickr.css` inline rather than importing it, and that port copied the `.numInputWrapper` wrapper/input rules but skipped **every** `.numInputWrapper span` rule — so the arrows had no geometry or glyphs.
2. An explicit `display: none` on `.flatpickr-current-month .numInputWrapper span.arrowUp/.arrowDown`.

Both are scoped to `.flatpickr-current-month`, which is why the **time** picker's arrows were unaffected.

Note for anyone reading CSA-92602: its description attributes this to `@cognigy/chat-components` using react-datepicker and missing `showYearDropdown`. That is incorrect — this library uses Flatpickr, and nothing was missing or reimplemented. The ticket also routes the fix away from this repo, which is likewise wrong.

# Security

- [x] No security implications

# Accessibility (WCAG 2.2 AA)

- [ ] New message types have a case entry in `test/fixtures/message-cases.ts` — N/A, not a new message type.
- [ ] Interaction spec added/updated — **intentionally not added, see below.**

DOM and JS behaviour are unchanged: flatpickr's click handlers were always bound, and the keyboard path already worked (`flatpickr.js` handles ArrowUp/Down on the focused year input; `setYearSelectAlly()` already sets `tabindex="0"`; Shift+PageUp/PageDown from the grid is covered by `test/DatepickerA11y.spec.tsx:242`). Only CSS visibility changed.

That also means **no automated test in this repo can distinguish before from after.** Vitest runs under jsdom and `vite.config.ts` sets only `css.modules.classNameStrategy`, so stylesheets are never applied — `fireEvent.click` on the arrows passes identically with and without the `display: none`. There is no browser test stack here. The screenshots are therefore the load-bearing evidence, not decoration.

Non-text contrast (1.4.11) checked manually since axe cannot: glyph is `--cc-black-10` (#1a1a1a) on white ≈ 17:1. The disabled state uses `--cc-black-80` (#ccc), matching the existing nav-arrow treatment; disabled controls are exempt from 1.4.11.

Gates run locally: `npm run build`, `npm test` (238 passed), `npm run test:a11y` (44 passed), `npm run lint:a11y` — all green.

# Additional considerations

- [ ] This PR might have performance implications

# Documentation Considerations

None — this restores intended behaviour, with no API or configuration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
